### PR TITLE
feat(3.1): add CurrencyCode value object with ISO 4217 validation

### DIFF
--- a/src/CurrencyTracker.Domain/Currencies/CurrencyCode.cs
+++ b/src/CurrencyTracker.Domain/Currencies/CurrencyCode.cs
@@ -1,0 +1,97 @@
+using CurrencyTracker.Domain.Common;
+
+namespace CurrencyTracker.Domain.Currencies;
+
+/// <summary>
+/// ISO 4217 three-letter uppercase currency code (e.g. <c>USD</c>,
+/// <c>EUR</c>). Validated against a static known-codes set on
+/// construction via <see cref="Create"/>. The numeric ISO 4217 code is
+/// not modelled here — it's a property of the <see cref="Currency"/>
+/// entity (issue 3.3).
+/// </summary>
+public readonly record struct CurrencyCode
+{
+    private static readonly IReadOnlySet<string> KnownCodes = new HashSet<string>(
+        StringComparer.Ordinal
+    )
+    {
+        "USD",
+        "EUR",
+        "GBP",
+        "JPY",
+        "CHF",
+        "CAD",
+        "AUD",
+        "NZD",
+        "CNY",
+        "INR",
+        "BRL",
+        "ZAR",
+        "MXN",
+        "SGD",
+        "HKD",
+    };
+
+    /// <summary>Gets the three-letter uppercase ISO 4217 code.</summary>
+    public string Value { get; }
+
+    private CurrencyCode(string value) => Value = value;
+
+    /// <summary>
+    /// Validates the supplied raw input as an ISO 4217 alphabetic
+    /// currency code and returns a <see cref="Result{CurrencyCode}"/>.
+    /// Rejects null/empty, wrong-length, non-uppercase-letter, and
+    /// unknown-code inputs with a stable error code per branch.
+    /// </summary>
+    /// <param name="raw">Candidate input — typically straight from a
+    /// JSON deserialiser or query string.</param>
+    /// <returns>Success carrying the parsed code, or failure with a
+    /// <see cref="DomainError"/> identifying the rejected branch.</returns>
+    public static Result<CurrencyCode> Create(string raw)
+    {
+        if (string.IsNullOrEmpty(raw))
+        {
+            return Result<CurrencyCode>.Failure(
+                DomainError.Validation("CURRENCY_CODE_REQUIRED", "A currency code is required.")
+            );
+        }
+
+        if (raw.Length != 3)
+        {
+            return Result<CurrencyCode>.Failure(
+                DomainError.Validation(
+                    "CURRENCY_CODE_LENGTH",
+                    "A currency code must be exactly three characters."
+                )
+            );
+        }
+
+        foreach (var ch in raw)
+        {
+            if (ch is < 'A' or > 'Z')
+            {
+                return Result<CurrencyCode>.Failure(
+                    DomainError.Validation(
+                        "CURRENCY_CODE_FORMAT",
+                        "A currency code must contain only uppercase ASCII letters."
+                    )
+                );
+            }
+        }
+
+        if (!KnownCodes.Contains(raw))
+        {
+            return Result<CurrencyCode>.Failure(
+                DomainError.Validation(
+                    "CURRENCY_CODE_UNKNOWN",
+                    $"'{raw}' is not a currency this application supports."
+                )
+            );
+        }
+
+        return Result<CurrencyCode>.Success(new CurrencyCode(raw));
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => Value;
+}

--- a/tests/CurrencyTracker.Domain.UnitTests/Currencies/CurrencyCodeTests.cs
+++ b/tests/CurrencyTracker.Domain.UnitTests/Currencies/CurrencyCodeTests.cs
@@ -1,0 +1,97 @@
+using CurrencyTracker.Domain.Currencies;
+
+namespace CurrencyTracker.Domain.UnitTests.Currencies;
+
+/// <summary>
+/// Tests covering <see cref="CurrencyCode"/>'s validation pipeline,
+/// equality semantics, and <c>ToString</c> formatting.
+/// </summary>
+public sealed class CurrencyCodeTests
+{
+    [Theory]
+    [InlineData("USD")]
+    [InlineData("EUR")]
+    [InlineData("GBP")]
+    [InlineData("JPY")]
+    public void Create_known_three_letter_code_succeeds(string raw)
+    {
+        var result = CurrencyCode.Create(raw);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Value.Should().Be(raw);
+    }
+
+    [Fact]
+    public void Create_null_returns_failure_with_CURRENCY_CODE_REQUIRED()
+    {
+        var result = CurrencyCode.Create(null!);
+
+        result.IsFailure.Should().BeTrue();
+        result.DomainError.Code.Should().Be("CURRENCY_CODE_REQUIRED");
+    }
+
+    [Fact]
+    public void Create_empty_returns_failure_with_CURRENCY_CODE_REQUIRED()
+    {
+        var result = CurrencyCode.Create("");
+
+        result.DomainError.Code.Should().Be("CURRENCY_CODE_REQUIRED");
+    }
+
+    [Theory]
+    [InlineData("US")]
+    [InlineData("USDX")]
+    public void Create_wrong_length_returns_failure_with_CURRENCY_CODE_LENGTH(string raw)
+    {
+        var result = CurrencyCode.Create(raw);
+
+        result.DomainError.Code.Should().Be("CURRENCY_CODE_LENGTH");
+    }
+
+    [Theory]
+    [InlineData("usd")]
+    [InlineData("Usd")]
+    [InlineData("US1")]
+    [InlineData("U$D")]
+    public void Create_non_uppercase_letters_returns_failure_with_CURRENCY_CODE_FORMAT(string raw)
+    {
+        var result = CurrencyCode.Create(raw);
+
+        result.DomainError.Code.Should().Be("CURRENCY_CODE_FORMAT");
+    }
+
+    [Fact]
+    public void Create_unknown_three_uppercase_letters_returns_failure_with_CURRENCY_CODE_UNKNOWN()
+    {
+        var result = CurrencyCode.Create("XYZ");
+
+        result.DomainError.Code.Should().Be("CURRENCY_CODE_UNKNOWN");
+    }
+
+    [Fact]
+    public void ToString_returns_the_underlying_value()
+    {
+        var sut = CurrencyCode.Create("USD").Value;
+
+        sut.ToString().Should().Be("USD");
+    }
+
+    [Fact]
+    public void Two_codes_with_the_same_value_are_equal()
+    {
+        var a = CurrencyCode.Create("USD").Value;
+        var b = CurrencyCode.Create("USD").Value;
+
+        a.Should().Be(b);
+        (a == b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Two_codes_with_different_values_are_not_equal()
+    {
+        var a = CurrencyCode.Create("USD").Value;
+        var b = CurrencyCode.Create("EUR").Value;
+
+        a.Should().NotBe(b);
+    }
+}


### PR DESCRIPTION
Close #52 