### PR TITLE
ci(8.10): add infrastructure-integration-tests job (Linux-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,37 @@ jobs:
 
       - name: Run aspire smoke
         run: dotnet test tests/CurrencyTracker.AppHost.SmokeTests --configuration Release --no-build
+
+  infrastructure-integration-tests:
+    name: infrastructure-integration-tests
+    runs-on: ubuntu-latest
+    needs: ci
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/packages.lock.json', 'Directory.Packages.props') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
+
+      - name: Restore
+        run: dotnet restore --locked-mode
+
+      - name: Build integration tests
+        run: dotnet build tests/CurrencyTracker.Infrastructure.IntegrationTests --configuration Release --no-restore
+
+      - name: Run integration tests
+        run: dotnet test tests/CurrencyTracker.Infrastructure.IntegrationTests --configuration Release --no-build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,11 @@ Every PR runs locally and in CI:
   the injected value automatically. A connection string in
   `appsettings.json` would shadow the Aspire-injected one and break the
   local-vs-Azure parity story Phase 14's Key Vault flow depends on.
+- Integration tests in `tests/CurrencyTracker.Infrastructure.IntegrationTests/`
+  require Docker and run on the Linux CI leg only. Locally, they run
+  on Windows / Mac when Docker Desktop is up; on GitHub Actions
+  they're Linux-only because the `windows-latest` runner doesn't
+  support Linux containers in the way Testcontainers needs.
 
 ## How to update this file
 


### PR DESCRIPTION
Close #165 