### PR TITLE
ci: skip build/test/integration on doc-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,43 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect non-doc changes
+        id: filter
+        shell: bash
+        run: |
+            # On push to main / manual dispatch, always run the full pipeline.
+            if [ "${{ github.event_name }}" != "pull_request" ]; then
+                echo "code=true" >> "$GITHUB_OUTPUT"
+                echo "::notice::${{ github.event_name }} event - running full CI."
+                exit 0
+            fi
+            base="${{ github.event.pull_request.base.sha }}"
+            changed="$(git diff --name-only "$base" HEAD)"
+            echo "Changed files:"
+            echo "$changed"
+            # code = any changed file that is NOT a doc (skippable set: **/*.md, docs/**).
+            if printf '%s\n' "$changed" | grep -vqE '(\.md$|^docs/)'; then
+                echo "code=true" >> "$GITHUB_OUTPUT"
+            else
+                echo "code=false" >> "$GITHUB_OUTPUT"
+                echo "::notice::Doc-only change - skipping build, tests, and integration jobs."
+            fi
+
   ci:
     name: ci
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -67,7 +102,7 @@ jobs:
 
       - name: Build
         if: steps.detect.outputs.has_csharp == 'true'
-        run: dotnet build -c --no-restore
+        run: dotnet build -c Release --no-restore
 
       - name: Test
         if: steps.detect.outputs.has_csharp == 'true'
@@ -75,8 +110,10 @@ jobs:
 
   aspire-smoke:
     name: aspire-smoke
+    needs: [changes, ci]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    needs: ci
+			 
     timeout-minutes: 5
 
     steps:
@@ -109,8 +146,10 @@ jobs:
 
   infrastructure-integration-tests:
     name: infrastructure-integration-tests
+    needs: [changes, ci]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    needs: ci
+			 
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,6 @@ jobs:
     needs: [changes, ci]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-			 
     timeout-minutes: 5
 
     steps:
@@ -149,7 +148,6 @@ jobs:
     needs: [changes, ci]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-			 
     timeout-minutes: 5
 
     steps:

--- a/CurrencyTracker.slnx
+++ b/CurrencyTracker.slnx
@@ -18,6 +18,7 @@
     <File Path="docs/decisions/0005-wiremock-http-stubbing.md" />
     <File Path="docs/decisions/0006-wolverine-service-location-for-internal-adapters.md" />
     <File Path="docs/decisions/0007-redis-distributed-cache.md" />
+    <File Path="docs/decisions/0008-openapi-ui.md" />
     <File Path="docs/decisions/0009-postgres-image-pin.md" />
   </Folder>
   <Folder Name="/Solution Items/">


### PR DESCRIPTION
Adds a lightweight changes job that diffs the PR against its base and sets code=false when every changed file is a doc (**/*.md, docs/**). The ci, aspire-smoke, and infrastructure-integration-tests jobs now run only when code=true. The filter is applied at the job level, not on the on: trigger, on purpose: a workflow skipped by paths-ignore leaves its required checks stuck in "Expected — waiting for status" and blocks the merge, whereas a job skipped by an if: condition reports Success and satisfies the required check (per GitHub's required-status-check docs). No branch-protection changes are needed; the three required checks still exist and pass (as skips) on doc-only PRs.