### PR TITLE
feat(13.8): /health/live + /health/ready with postgres+redis readiness checks

### DIFF
--- a/src/CurrencyTracker.Api/CurrencyTracker.Api.csproj
+++ b/src/CurrencyTracker.Api/CurrencyTracker.Api.csproj
@@ -24,6 +24,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="CurrencyTracker.Api.IntegrationTests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Folder Include="Exceptions\" />
     </ItemGroup>
 </Project>

--- a/src/CurrencyTracker.Api/Health/HealthCheckExtensions.cs
+++ b/src/CurrencyTracker.Api/Health/HealthCheckExtensions.cs
@@ -1,0 +1,30 @@
+namespace CurrencyTracker.Api.Health;
+
+/// <summary>
+/// Composition-root registration for the Api's app-specific readiness
+/// checks. Kept out of <c>ServiceDefaults</c> (which stays generic): the
+/// Postgres and Redis dependencies are known only here, where the API host
+/// composes them. Both checks are tagged <c>ready</c> so the
+/// <c>/health/ready</c> endpoint can select them by tag.
+/// </summary>
+public static class HealthCheckExtensions
+{
+    /// <summary>
+    /// Adds the Postgres and Redis readiness checks (tag <c>ready</c>) to the
+    /// health-check set already seeded with the generic <c>self</c>/<c>live</c>
+    /// check by <c>ServiceDefaults</c>.
+    /// </summary>
+    /// <param name="builder">The API host builder.</param>
+    /// <returns>The same <paramref name="builder"/> for chaining.</returns>
+    public static IHostApplicationBuilder AddApiReadinessChecks(
+        this IHostApplicationBuilder builder
+    )
+    {
+        builder
+            .Services.AddHealthChecks()
+            .AddCheck<PostgresHealthCheck>("postgres", tags: ["ready"])
+            .AddCheck<RedisHealthCheck>("redis", tags: ["ready"]);
+
+        return builder;
+    }
+}

--- a/src/CurrencyTracker.Api/Health/PostgresHealthCheck.cs
+++ b/src/CurrencyTracker.Api/Health/PostgresHealthCheck.cs
@@ -1,0 +1,29 @@
+// src/CurrencyTracker.Api/Health/PostgresHealthCheck.cs
+using CurrencyTracker.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace CurrencyTracker.Api.Health;
+
+/// <summary>
+/// Readiness check that reports whether the Api can reach Postgres. Uses
+/// <see cref="DatabaseFacade.CanConnectAsync(System.Threading.CancellationToken)"/>,
+/// which opens and closes a connection and returns <c>false</c> (rather
+/// than throwing) when the database is unreachable.
+/// </summary>
+/// <param name="dbContext">The application's EF Core context.</param>
+internal sealed class PostgresHealthCheck(ApplicationDbContext dbContext) : IHealthCheck
+{
+    /// <inheritdoc />
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        var canConnect = await dbContext.Database.CanConnectAsync(cancellationToken);
+
+        return canConnect
+            ? HealthCheckResult.Healthy("Postgres is reachable.")
+            : HealthCheckResult.Unhealthy("Postgres is not reachable.");
+    }
+}

--- a/src/CurrencyTracker.Api/Health/RedisHealthCheck.cs
+++ b/src/CurrencyTracker.Api/Health/RedisHealthCheck.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace CurrencyTracker.Api.Health;
+
+/// <summary>
+/// Readiness check that reports whether the Api can reach Redis. Probes the
+/// same <see cref="IDistributedCache"/> the Phase 10 cache path uses, so a
+/// healthy answer means the cache path itself is reachable. A read for a
+/// missing key is a full round-trip; if Redis is down the read throws, and
+/// the health-check framework reports the check <c>Unhealthy</c> — so there
+/// is deliberately no broad <c>catch</c> here.
+/// </summary>
+/// <param name="cache">The distributed cache registered in Phase 10.</param>
+internal sealed class RedisHealthCheck(IDistributedCache cache) : IHealthCheck
+{
+    private const string ProbeKey = "health:ready:redis-probe";
+
+    /// <inheritdoc />
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken
+    )
+    {
+        _ = await cache.GetAsync(ProbeKey, cancellationToken);
+
+        return HealthCheckResult.Healthy("Redis is reachable.");
+    }
+}

--- a/src/CurrencyTracker.Api/Program.cs
+++ b/src/CurrencyTracker.Api/Program.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using CurrencyTracker.Api.ErrorHandling;
+using CurrencyTracker.Api.Health;
 using CurrencyTracker.Application;
 using CurrencyTracker.Application.Abstractions.Notifications;
 using CurrencyTracker.Application.Abstractions.Persistence;
@@ -8,6 +9,7 @@ using CurrencyTracker.Application.Messaging;
 using CurrencyTracker.Infrastructure;
 using CurrencyTracker.ServiceDefaults;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks; // HealthCheckOptions
 using Microsoft.IdentityModel.Tokens;
 using Scalar.AspNetCore;
 using Wolverine;
@@ -53,6 +55,8 @@ builder.UseWolverine(opts =>
     opts.CodeGeneration.AlwaysUseServiceLocationFor<IUnitOfWork>();
     opts.CodeGeneration.AlwaysUseServiceLocationFor<IAlertNotifier>(); // + 12.8
 });
+
+builder.AddApiReadinessChecks(); // ← 13.8: postgres + redis readiness checks (tag "ready")
 
 builder.Services.AddOpenApi();
 builder.Services.AddWolverineHttp();
@@ -155,6 +159,19 @@ app.UseStatusCodePages(); // ← added in 11.7 (empty-body 401/403 -> problem+js
 app.UseAuthentication(); // ← added in 11.4 (validates a presented token; rejects nothing yet)
 app.UseAuthorization(); // ← added in 11.4 (no RequireAuthorization until 11.7)
 app.MapDefaultEndpoints();
+
+// 13.8: named liveness/readiness probes. Anonymous by construction —
+// MapHealthChecks endpoints are not Wolverine endpoints, so RequireAuthorizeOnAll
+// (which only decorates the Wolverine set) never touches them, matching Phase 11's
+// anonymous /health + /alive decision.
+app.MapHealthChecks(
+    "/health/live",
+    new HealthCheckOptions { Predicate = registration => registration.Tags.Contains("live") }
+);
+app.MapHealthChecks(
+    "/health/ready",
+    new HealthCheckOptions { Predicate = registration => registration.Tags.Contains("ready") }
+);
 app.MapWolverineEndpoints(opts => opts.RequireAuthorizeOnAll()); // ← 11.7: secure-by-default
 
 app.UseHttpsRedirection();

--- a/tests/CurrencyTracker.Api.IntegrationTests/Health/HealthEndpointsTests.cs
+++ b/tests/CurrencyTracker.Api.IntegrationTests/Health/HealthEndpointsTests.cs
@@ -1,0 +1,33 @@
+using CurrencyTracker.Api.IntegrationTests.Rates;
+
+namespace CurrencyTracker.Api.IntegrationTests.Health;
+
+/// <summary>
+/// Proves the 13.8 liveness/readiness contract against a live Postgres and
+/// Redis (via <see cref="RatesApiFixture"/>): liveness is up while the
+/// process runs, readiness is up only when both stores are reachable.
+/// </summary>
+public sealed class HealthEndpointsTests(RatesApiFixture fixture) : IClassFixture<RatesApiFixture>
+{
+    [Fact]
+    public async Task Live_returns_200_while_the_process_runs()
+    {
+        // Act / Assert
+        await fixture.Host.Scenario(scenario =>
+        {
+            scenario.Get.Url("/health/live");
+            scenario.StatusCodeShouldBe(200);
+        });
+    }
+
+    [Fact]
+    public async Task Ready_returns_200_when_postgres_and_redis_are_reachable()
+    {
+        // Act / Assert
+        await fixture.Host.Scenario(scenario =>
+        {
+            scenario.Get.Url("/health/ready");
+            scenario.StatusCodeShouldBe(200);
+        });
+    }
+}

--- a/tests/CurrencyTracker.Api.IntegrationTests/Health/HealthReadinessFlipTests.cs
+++ b/tests/CurrencyTracker.Api.IntegrationTests/Health/HealthReadinessFlipTests.cs
@@ -1,0 +1,71 @@
+using Alba;
+using CurrencyTracker.Api.IntegrationTests.Auth;
+using Testcontainers.PostgreSql;
+
+namespace CurrencyTracker.Api.IntegrationTests.Health;
+
+/// <summary>
+/// Boots the Api with Postgres reachable but Redis pointed at a dead port,
+/// proving readiness flips to 503 while liveness stays 200.
+/// </summary>
+public sealed class HealthReadinessFlipTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:18")
+        .WithDatabase("currencytracker")
+        .Build();
+
+    private IAlbaHost _host = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await _postgres.StartAsync();
+
+        _host = await AlbaHost.For<Program>(builder =>
+        {
+            builder.UseSetting(
+                "ConnectionStrings:currencytracker",
+                _postgres.GetConnectionString()
+            );
+            // Nothing listening on 6390 → the Redis readiness probe's GetAsync throws.
+            builder.UseSetting(
+                "ConnectionStrings:cache",
+                "127.0.0.1:6390,connectTimeout=250,connectRetry=1,abortConnect=false"
+            );
+            builder.UseSetting(
+                "Authentication:Authority",
+                "https://test.local/realms/currency-tracker"
+            );
+            builder.UseSetting("Authentication:Audience", "currency-tracker-api");
+            builder.UseTestJwtBearer();
+            builder.UseStubExchangeRateProvider();
+        });
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.DisposeAsync();
+        await _postgres.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Ready_flips_to_503_when_redis_is_unreachable()
+    {
+        // Act / Assert
+        await _host.Scenario(scenario =>
+        {
+            scenario.Get.Url("/health/ready");
+            scenario.StatusCodeShouldBe(503);
+        });
+    }
+
+    [Fact]
+    public async Task Live_stays_200_when_redis_is_unreachable()
+    {
+        // Act / Assert
+        await _host.Scenario(scenario =>
+        {
+            scenario.Get.Url("/health/live");
+            scenario.StatusCodeShouldBe(200);
+        });
+    }
+}

--- a/tests/CurrencyTracker.Api.IntegrationTests/Health/RedisHealthCheckTests.cs
+++ b/tests/CurrencyTracker.Api.IntegrationTests/Health/RedisHealthCheckTests.cs
@@ -1,0 +1,33 @@
+using CurrencyTracker.Api.Health;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using NSubstitute;
+
+namespace CurrencyTracker.Api.IntegrationTests.Health;
+
+/// <summary>
+/// Unit-level coverage of the <see cref="RedisHealthCheck"/> seam: a
+/// responsive cache yields Healthy. The unreachable path (GetAsync throws →
+/// framework reports Unhealthy) is proven end-to-end in
+/// <see cref="HealthReadinessFlipTests"/>.
+/// </summary>
+public sealed class RedisHealthCheckTests
+{
+    [Fact]
+    public async Task Returns_healthy_when_the_cache_responds()
+    {
+        // Arrange
+        var cache = Substitute.For<IDistributedCache>();
+        cache.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((byte[]?)null);
+        var check = new RedisHealthCheck(cache);
+
+        // Act
+        var result = await check.CheckHealthAsync(
+            new HealthCheckContext(),
+            TestContext.Current.CancellationToken
+        );
+
+        // Assert
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+}


### PR DESCRIPTION
close #303 