### PR TITLE
iac(14.C): fix first UAT apply — registry bootstrap, storage auth, Managed Redis

### DIFF
--- a/infra/terraform/envs/prod/terraform.tfvars
+++ b/infra/terraform/envs/prod/terraform.tfvars
@@ -24,6 +24,9 @@ vnet_address_space = ["10.30.0.0/16"]
 # = true above). Burstable + HA is an apply-time error.
 postgres_sku_name = "GP_Standard_D2s_v3"
 
-# Standard adds replication + SLA; C1 is the smallest sensible production size.
-redis_sku_name = "Standard"
-redis_capacity = 1
+# REVIEW BEFORE THE FIRST PROD APPLY. Standard/C1 died with Azure Cache for
+# Redis; this is a like-for-like guess at its replacement, not a costed choice.
+# high_availability_enabled is what buys the replica + SLA that "Standard" used
+# to imply — the SKU string no longer encodes it.
+redis_sku_name                  = "Balanced_B1"
+redis_high_availability_enabled = true

--- a/infra/terraform/envs/uat/terraform.tfvars
+++ b/infra/terraform/envs/uat/terraform.tfvars
@@ -26,5 +26,7 @@ vnet_address_space = ["10.20.0.0/16"]
 postgres_sku_name = "B_Standard_B1ms"
 
 # Smallest cache that exercises the real code path. No SLA — acceptable in UAT.
-redis_sku_name = "Basic"
-redis_capacity = 0
+# Balanced_B0 is Azure Managed Redis's entry tier and costs materially more than
+# the retired Basic/C0 it replaces; there is no cheaper AMR option.
+redis_sku_name                  = "Balanced_B0"
+redis_high_availability_enabled = false

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -76,7 +76,7 @@ module "redis" {
   resource_group_name          = data.azurerm_resource_group.env.name
   location                     = data.azurerm_resource_group.env.location
   sku_name                     = var.redis_sku_name
-  capacity                     = var.redis_capacity
+  high_availability_enabled    = var.redis_high_availability_enabled
   enable_public_network_access = var.enable_public_network_access
   private_endpoint_subnet_id   = module.network.private_endpoint_subnet_id
   vnet_id                      = module.network.vnet_id
@@ -176,7 +176,7 @@ module "role_assignments" {
 
   acr_id                       = module.acr.id
   key_vault_id                 = module.keyvault.id
-  redis_cache_id               = module.redis.id
+  managed_redis_id             = module.redis.id
   postgres_server_name         = module.postgres.name
   postgres_resource_group_name = data.azurerm_resource_group.env.name
 }

--- a/infra/terraform/modules/container-app-api/main.tf
+++ b/infra/terraform/modules/container-app-api/main.tf
@@ -13,11 +13,20 @@ resource "azurerm_container_app" "api" {
     type = "SystemAssigned"
   }
 
-  # How to authenticate to the ACR when an image lives there. Inert against
-  # the public placeholder; live the moment 14.D deploys <acr>/...:sha.
-  registry {
-    server   = var.acr_login_server
-    identity = "System"
+  # How to authenticate to the ACR when an image lives there. NOT inert against
+  # the public placeholder: Container Apps resolves registry credentials while
+  # provisioning the revision, whatever the image's origin. Declaring it before
+  # 14.24 grants AcrPull is a bootstrap cycle — the grant needs the identity,
+  # the identity is minted here — and the revision never provisions (ACR token
+  # exchange 401s until the platform gives up: "Operation expired"). So it stays
+  # off until the same change that points `image` at the ACR.
+  dynamic "registry" {
+    for_each = var.use_acr_registry ? [1] : []
+
+    content {
+      server   = var.acr_login_server
+      identity = "System"
+    }
   }
 
   ingress {

--- a/infra/terraform/modules/container-app-api/variables.tf
+++ b/infra/terraform/modules/container-app-api/variables.tf
@@ -18,6 +18,12 @@ variable "acr_login_server" {
   type        = string
 }
 
+variable "use_acr_registry" {
+  description = "Declare the ACR registry credential on the app. Must stay false until 14.24's AcrPull grant exists for this app's identity — see the bootstrap-cycle note in main.tf. Flip it in the same change that points `image` at the ACR."
+  type        = bool
+  default     = false
+}
+
 variable "image" {
   description = "Bootstrap image only. Public placeholder listening on 8080; after first apply the deploy pipeline owns the image (ignore_changes)."
   type        = string

--- a/infra/terraform/modules/container-app-worker/main.tf
+++ b/infra/terraform/modules/container-app-worker/main.tf
@@ -16,9 +16,14 @@ resource "azurerm_container_app" "worker" {
     type = "SystemAssigned"
   }
 
-  registry {
-    server   = var.acr_login_server
-    identity = "System"
+  # Off until 14.D — same bootstrap cycle as the API; see that module's comment.
+  dynamic "registry" {
+    for_each = var.use_acr_registry ? [1] : []
+
+    content {
+      server   = var.acr_login_server
+      identity = "System"
+    }
   }
 
   dynamic "secret" {

--- a/infra/terraform/modules/container-app-worker/variables.tf
+++ b/infra/terraform/modules/container-app-worker/variables.tf
@@ -18,6 +18,12 @@ variable "acr_login_server" {
   type        = string
 }
 
+variable "use_acr_registry" {
+  description = "Declare the ACR registry credential on the app. Must stay false until 14.24's AcrPull grant exists for this app's identity — see the bootstrap-cycle note in the API module. Flip it in the same change that points `image` at the ACR."
+  type        = bool
+  default     = false
+}
+
 variable "image" {
   description = "Bootstrap image only; the deploy pipeline owns the image after first apply (ignore_changes)."
   type        = string

--- a/infra/terraform/modules/redis/main.tf
+++ b/infra/terraform/modules/redis/main.tf
@@ -1,5 +1,13 @@
-# Azure Cache for Redis, hardened per the build plan's secure defaults.
-# The three hardening arguments are invariants, not variables.
+# Azure Managed Redis, hardened per the build plan's secure defaults. The
+# hardening arguments are invariants, not variables.
+#
+# This module was Azure Cache for Redis (azurerm_redis_cache) until that product
+# entered retirement: the RedisCreate API now rejects every new instance with
+# "Azure Cache for Redis is retiring, create Azure Managed Redis instance
+# instead" (aka.ms/AzureCacheForRedisRetirement). Not a migration we chose.
+#
+# AMR is ONE resource: the database is a nested default_database block, not a
+# separate resource, and AMR permits exactly one of them.
 
 resource "random_string" "suffix" {
   length  = 4
@@ -9,42 +17,63 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  # Cache names are global DNS labels: <name>.redis.cache.windows.net.
+  # Cache names are global DNS labels: <name>.<region>.redis.azure.net.
   cache_name = "redis-${var.name_prefix}-${random_string.suffix.result}"
   private    = var.enable_public_network_access == false
 }
 
-resource "azurerm_redis_cache" "this" {
+resource "azurerm_managed_redis" "this" {
   name                = local.cache_name
   resource_group_name = var.resource_group_name
   location            = var.location
 
+  # One SKU string replaces the old sku_name + family + capacity triple.
+  # Balanced_B0 is the entry tier — AMR has no equivalent of Basic/C0.
   sku_name = var.sku_name
-  family   = "C" # Basic/Standard family; Premium (P) has no issue in this phase
-  capacity = var.capacity
 
-  # Hardening invariants: plaintext port stays closed, TLS 1.2 floor,
-  # Entra tokens accepted (14.24 assigns the access policy; 14.E connects).
-  non_ssl_port_enabled = false
-  minimum_tls_version  = "1.2"
+  # PROD buys the replica + SLA; UAT deliberately does not (cost).
+  high_availability_enabled = var.high_availability_enabled
 
-  redis_configuration {
-    active_directory_authentication_enabled = true
-    # access_keys_authentication_enabled stays at its default (true) until
-    # 14.E moves the app onto Entra tokens; 14.G closes the key path.
+  # A string on AMR, not the bool the retired product took.
+  public_network_access = var.enable_public_network_access ? "Enabled" : "Disabled"
+
+  default_database {
+    # Hardening invariant: plaintext is refused outright. Encrypted replaces
+    # non_ssl_port_enabled = false + minimum_tls_version, which AMR folds into
+    # this single argument.
+    client_protocol = "Encrypted"
+
+    # EnterpriseCluster exposes the single-endpoint, non-clustered Redis API
+    # that StackExchange.Redis speaks by default. OSSCluster would require a
+    # cluster-aware client — a Phase 10 code change, not a Terraform knob.
+    clustering_policy = "EnterpriseCluster"
+
+    # Matches the volatile-lru default the retired Basic tier ran under, so the
+    # Phase 10 query-slice cache keeps its existing eviction behaviour.
+    eviction_policy = "VolatileLRU"
+
+    # Entra-only from birth. AMR inverts the retired product's default: access
+    # keys are OFF unless asked for, so the key path 14.G was going to close is
+    # already shut and 14.E has no interim key-auth step to lean on. Pinned
+    # explicitly rather than left to a default that differs per product.
+    # Entra auth itself needs no flag — it is the 14.24 access-policy assignment.
+    access_keys_authentication_enabled = false
   }
-
-  public_network_access_enabled = var.enable_public_network_access
 
   tags = var.tags
 }
 
 # PROD-only private path: endpoint in the shared PE subnet + the service's
 # privatelink zone linked into the environment VNet.
+#
+# UNVERIFIED — the zone name and subresource below follow the redisEnterprise
+# ARM type, but no PROD apply has exercised them and the retirement moved this
+# service's private-link naming. Confirm both against the AMR private-link docs
+# before the first PROD apply; UAT (public posture) never instantiates them.
 resource "azurerm_private_dns_zone" "redis" {
   count = local.private ? 1 : 0
 
-  name                = "privatelink.redis.cache.windows.net"
+  name                = "privatelink.redis.azure.net"
   resource_group_name = var.resource_group_name
   tags                = var.tags
 }
@@ -69,8 +98,8 @@ resource "azurerm_private_endpoint" "redis" {
 
   private_service_connection {
     name                           = "psc-${var.name_prefix}-redis"
-    private_connection_resource_id = azurerm_redis_cache.this.id
-    subresource_names              = ["redisCache"]
+    private_connection_resource_id = azurerm_managed_redis.this.id
+    subresource_names              = ["redisEnterprise"]
     is_manual_connection           = false
   }
 

--- a/infra/terraform/modules/redis/outputs.tf
+++ b/infra/terraform/modules/redis/outputs.tf
@@ -1,14 +1,19 @@
 output "id" {
-  description = "Cache resource ID (the 14.24 access-policy assignment targets it)."
-  value       = azurerm_redis_cache.this.id
+  description = "Managed Redis resource ID (the 14.24 access-policy assignment targets it)."
+  value       = azurerm_managed_redis.this.id
 }
 
 output "name" {
   description = "Cache name."
-  value       = azurerm_redis_cache.this.name
+  value       = azurerm_managed_redis.this.name
 }
 
 output "hostname" {
-  description = "Cache hostname — the host the 14.E connection configuration points at (TLS port 6380)."
-  value       = azurerm_redis_cache.this.hostname
+  description = "Cache hostname — the host the 14.E connection configuration points at."
+  value       = azurerm_managed_redis.this.hostname
+}
+
+output "port" {
+  description = "TLS port for client connections. Read from the resource rather than assumed: AMR does not use the 6380 the retired product did, and 14.E must not inherit the old value."
+  value       = azurerm_managed_redis.this.default_database[0].port
 }

--- a/infra/terraform/modules/redis/variables.tf
+++ b/infra/terraform/modules/redis/variables.tf
@@ -14,13 +14,13 @@ variable "location" {
 }
 
 variable "sku_name" {
-  description = "Cache SKU: Basic, Standard, or Premium."
+  description = "Azure Managed Redis SKU, e.g. Balanced_B0 (entry tier), Balanced_B1, MemoryOptimized_M10. Replaces the retired product's sku_name + family + capacity triple."
   type        = string
 }
 
-variable "capacity" {
-  description = "Cache size within the C family (0-6)."
-  type        = number
+variable "high_availability_enabled" {
+  description = "Provision the replica that carries the SLA (PROD). false halves the cost and drops the SLA — the UAT posture, mirroring postgres_zone_redundant."
+  type        = bool
 }
 
 variable "enable_public_network_access" {

--- a/infra/terraform/modules/role-assignments/main.tf
+++ b/infra/terraform/modules/role-assignments/main.tf
@@ -55,11 +55,15 @@ resource "azurerm_postgresql_flexible_server_active_directory_administrator" "ap
 
 # --- Redis: Data Contributor access policy — API ONLY. The Worker never
 # opens a cache connection (query slice is API-side; docs/caching.md), so it
-# gets no grant. Asymmetry on purpose; grants follow code. -------------------
-resource "azurerm_redis_cache_access_policy_assignment" "api_data_contributor" {
-  name               = "api-data-contributor"
-  redis_cache_id     = var.redis_cache_id
-  access_policy_name = "Data Contributor"
-  object_id          = var.api_principal_id
-  object_id_alias    = "ServicePrincipal"
+# gets no grant. Asymmetry on purpose; grants follow code.
+#
+# (Was azurerm_redis_cache_access_policy_assignment until the Azure Cache for
+# Redis retirement forced modules/redis onto AMR.) The AMR resource takes only
+# the target and the principal: no name, and no policy name — AMR exposes a
+# single built-in access policy, so there is nothing to select. That also means
+# no object_id_alias, so this grant has no equivalent of the principal_type
+# hint above; a just-created identity may need a retry while Entra replicates.
+resource "azurerm_managed_redis_access_policy_assignment" "api_data_contributor" {
+  managed_redis_id = var.managed_redis_id
+  object_id        = var.api_principal_id
 }

--- a/infra/terraform/modules/role-assignments/variables.tf
+++ b/infra/terraform/modules/role-assignments/variables.tf
@@ -18,8 +18,8 @@ variable "key_vault_id" {
   type        = string
 }
 
-variable "redis_cache_id" {
-  description = "Redis cache resource ID — Data Contributor access-policy target."
+variable "managed_redis_id" {
+  description = "Managed Redis resource ID — access-policy assignment target."
   type        = string
 }
 

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -5,6 +5,11 @@ provider "azurerm" {
   # provider-level behaviours for certain resource types, tuned per module later.
   features {}
 
+  # Storage data-plane calls go over Entra, not shared keys. modules/storage-logs
+  # sets shared_access_key_enabled = false, so the provider's post-create wait on
+  # the Blob service 403s (KeyBasedAuthenticationNotPermitted) without this.
+  storage_use_azuread = true
+
   # azurerm 4.x requires a subscription id. It is supplied via ARM_SUBSCRIPTION_ID
   # (locally from `az account show`; in CI from azure/login over OIDC) so the GUID
   # never lands in the repo. No client secret: auth is az login / OIDC federation.

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -48,11 +48,11 @@ variable "postgres_sku_name" {
 }
 
 variable "redis_sku_name" {
-  description = "Azure Cache for Redis SKU: Basic, Standard, or Premium."
+  description = "Azure Managed Redis SKU, e.g. Balanced_B0 (entry tier) or Balanced_B1. The old Basic/Standard/Premium + capacity pair died with Azure Cache for Redis."
   type        = string
 }
 
-variable "redis_capacity" {
-  description = "Cache size within the C family (0 = 250 MB upward)."
-  type        = number
+variable "redis_high_availability_enabled" {
+  description = "Whether the cache runs a replica for its SLA (true in PROD). Mirrors postgres_zone_redundant: PROD buys resilience, UAT buys the lower bill."
+  type        = bool
 }


### PR DESCRIPTION
Three independent defects surfaced by the first real `terraform apply` against UAT. Each is separately revertable; none was visible from `validate` or `plan`.

## `iac(14.22)` — ACR registry credential is not inert

The `registry` block on both container apps was commented as inert against the public placeholder image. It isn't: Container Apps resolves registry credentials while provisioning a revision, whatever the image's origin.

That made it a bootstrap cycle — the credential authenticates as the app's system-assigned identity, 14.24 grants that identity `AcrPull`, and 14.24 can't run until the identity exists, which happens only when the app is created. The ACR token exchange 401s on repeat until the platform gives up:

```
Failed to construct registry secret for registry 'crctuatajax.azurecr.io'.
Error: ACR token exchange endpoint returned error status: 401.   Count: 17
```

Terminating as `Operation expired` ~20 minutes in, with zero revisions provisioned. Both apps now gate the block on `use_acr_registry` (default `false`). **14.D flips it to `true` in the same change that points `image` at the ACR**, by which point the grant exists.

## `iac(14.25)` — storage data-plane calls used shared keys

`modules/storage-logs` sets `shared_access_key_enabled = false`, so the account has no key credential. The provider still polled the Blob service with key auth after create and got `403 KeyBasedAuthenticationNotPermitted` — after the account was created, leaving it tainted in state. `storage_use_azuread = true` moves those calls onto the caller's Entra identity, matching how the backend already authenticates (ADR 0014).

## `iac(14.18)` — Azure Cache for Redis is retiring

`azurerm_redis_cache` can no longer be created at all; the API returns a 400 pointing at [the retirement notice](https://aka.ms/AzureCacheForRedisRetirement). Forced, not chosen.

AMR is a single `azurerm_managed_redis` resource — the database is a nested `default_database` block, only one allowed.

| Was | Now |
|---|---|
| `sku_name` + `family` + `capacity` | one SKU string; `Balanced_B0` is the entry tier |
| `Standard` implied replica + SLA | explicit `high_availability_enabled` |
| `public_network_access_enabled` (bool) | `public_network_access` (string) |
| `non_ssl_port_enabled` + `minimum_tls_version` | `client_protocol` |
| port 6380 | **port 10000** |
| `azurerm_redis_cache_access_policy_assignment` | `azurerm_managed_redis_access_policy_assignment` |

### Reviewer attention

- **UAT costs more.** `Balanced_B0` is AMR's floor and materially exceeds the retired `Basic`/C0. There is no cheaper option.
- **Access keys now default to DISABLED** — the inverse of the retired product. Pinned explicitly. The key path 14.G was to close is already shut, and **14.E has no interim key-auth step to lean on**.
- **Port 10000, not 6380.** Exposed as a module output so 14.E can't inherit the old value by assumption.
- **PROD values are placeholders**, not costed choices — `Standard`/`C1` became invalid and prod had to stay plannable.
- **The PROD private-link path is marked `UNVERIFIED`** in the module. UAT runs the public posture and never instantiates it. Confirm `subresource_names` and the DNS zone before the first prod apply.
- The new grant takes no `object_id_alias`, so it has no `principal_type` hint and may need a retry while Entra replicates a just-created identity.

## Verification

Applied to UAT and confirmed:

- `terraform plan` → **No changes**
- `GET https://<api_fqdn>/` → **200**; plaintext `http://` → **301**
- API revision `Running`, worker revision `RunningAtMaxScale` (1 replica, per the unclustered-Quartz constraint)
- Redis `Succeeded` / `Balanced_B0`; database `Encrypted` · `EnterpriseCluster` · `VolatileLRU` · port `10000` · keys `Disabled`
- Exactly one access-policy assignment, targeting the API identity — worker correctly absent

Not covered: `/health/live` and `/health/ready` (not served by the placeholder, `health_probes_enabled` is `false`), end-to-end cache connectivity, the ACR pull path, and the PROD private-link path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
