### PR TITLE
refactor(ci): remove duplicated work from the PR pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS — review gate on the files that can change what CI is allowed to do.
+#
+# For `pull_request` events GitHub executes the workflow definition from the PR
+# HEAD, so a PR that edits a workflow runs with that edit. Concretely: flipping
+# terraform-pr.yml's `apply: false` to `true`, or adding a job that calls
+# _reusable-azure-deploy.yml, would execute against real Azure on the PR run.
+# Requiring an owner review on these paths is what closes that door.
+#
+# This only takes effect once branch protection on `main` enables
+# "Require review from Code Owners" (and a non-zero required approving review
+# count). Adding the file alone changes nothing.
+
+/.github/workflows/   @mpcs2013
+/.github/CODEOWNERS   @mpcs2013
+
+# Infrastructure-as-code reaches the same subscriptions the pipeline deploys to.
+/infra/               @mpcs2013

--- a/.github/workflows/_reusable-coverage-gate.yml
+++ b/.github/workflows/_reusable-coverage-gate.yml
@@ -1,0 +1,79 @@
+# _reusable-coverage-gate.yml — merge the raw Cobertura from every test job and
+# apply the 13.14 measured floor (floor = measured - 5; ratchet UP only).
+#
+# This lives in its own workflow because coverage is collected across three jobs
+# now: _reusable-test.yml (unit + architecture + Api integration) plus the two
+# isolated container suites. No single job sees the whole picture, so gating
+# inside any one of them would under-report and fail an honest build.
+#
+# The merge and gate steps are lifted verbatim from the pre-split
+# _reusable-test.yml — the reportgenerator invocation and the awk comparison are
+# unchanged, only their location moved. Callers: ci.yml, main-ci.yml.
+name: _reusable-coverage-gate
+
+on:
+  workflow_call:
+    inputs:
+      coverage-min:
+        description: Minimum line-coverage percentage (string, e.g. "58").
+        type: string
+        default: "58"
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      COVERAGE_MIN: ${{ inputs.coverage-min }}
+    steps:
+      # Every producer uploads `coverage-raw-*`; pattern-matching them means a
+      # future test job joins the gate just by following the naming convention.
+      - name: Download raw coverage
+        uses: actions/download-artifact@v7
+        with:
+          pattern: coverage-raw-*
+          path: coverage
+          merge-multiple: true
+
+      # A silent empty download would sail through reportgenerator and report a
+      # nonsense rate, so fail loudly instead.
+      - name: Verify artifacts arrived
+        shell: bash
+        run: |
+          count=$(find coverage -name 'coverage.cobertura.xml' | wc -l)
+          echo "Found $count raw Cobertura file(s)."
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No coverage.cobertura.xml files downloaded — the gate cannot run."
+            exit 1
+          fi
+
+      - name: Merge coverage report
+        run: |
+          dotnet tool install -g dotnet-reportgenerator-globaltool
+          reportgenerator \
+            -reports:"coverage/**/coverage.cobertura.xml" \
+            -targetdir:"coverage/report" \
+            -reporttypes:"Cobertura;TextSummary;MarkdownSummaryGithub"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage/report
+          retention-days: 14
+
+      - name: Coverage gate
+        shell: bash
+        run: |
+          line_rate=$(python3 -c "import xml.etree.ElementTree as ET; print(ET.parse('coverage/report/Cobertura.xml').getroot().get('line-rate'))")
+          pct=$(python3 -c "print(round(float('$line_rate') * 100, 1))")
+          echo "Line coverage: ${pct}%  (floor: ${COVERAGE_MIN}%)"
+          echo "### Coverage: ${pct}% (floor ${COVERAGE_MIN}%)" >> "$GITHUB_STEP_SUMMARY"
+          awk "BEGIN { exit !($pct >= $COVERAGE_MIN) }" || {
+            echo "::error::Line coverage ${pct}% is below the floor of ${COVERAGE_MIN}%."
+            exit 1
+          }

--- a/.github/workflows/_reusable-test.yml
+++ b/.github/workflows/_reusable-test.yml
@@ -1,6 +1,8 @@
-# _reusable-test.yml — restore + build + test with coverage and the
-# measured-floor gate (13.14: floor = measured - 5; ratchet UP only).
-# Self-contained; callers: ci.yml, main-ci.yml.
+# _reusable-test.yml — restore + build + the non-container test suites, emitting
+# raw Cobertura. The container-heavy suites (AppHost.SmokeTests,
+# Infrastructure.IntegrationTests) are excluded here and owned by dedicated
+# isolated jobs; _reusable-coverage-gate.yml merges all three and applies the
+# 13.14 measured floor. Callers: ci.yml, main-ci.yml.
 name: _reusable-test
 
 on:
@@ -14,10 +16,6 @@ on:
         description: Runner image.
         type: string
         default: ubuntu-latest
-      coverage-min:
-        description: Minimum line-coverage percentage (string, e.g. "58").
-        type: string
-        default: "58"
 
 permissions:
   contents: read
@@ -27,8 +25,6 @@ jobs:
     name: test
     runs-on: ${{ inputs.os }}
     timeout-minutes: 20
-    env:
-      COVERAGE_MIN: ${{ inputs.coverage-min }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -52,36 +48,44 @@ jobs:
       - name: Build
         run: dotnet build -c ${{ inputs.configuration }} --no-restore
 
+      # Discover test projects dynamically and skip only an explicit exclusion
+      # list. An include-list would be the more obvious spelling and the wrong
+      # one: a newly added test project would silently stop running, which is
+      # exactly how the pre-14.28 `has_csharp` gate disabled this pipeline for
+      # 350+ PRs. The two excluded suites are container-heavy and are owned by
+      # their own isolated jobs in ci.yml / main-ci.yml.
+      #
+      # `shopt -s globstar` is required — without it bash does not recurse `**`,
+      # which is the precise mechanic of that same historical bug.
       - name: Test
-        run: >
-          dotnet test -c ${{ inputs.configuration }} --no-build
-          --collect:"XPlat Code Coverage"
-          --settings coverlet.runsettings
-          --results-directory ${{ github.workspace }}/coverage
-
-      - name: Merge coverage report
-        run: |
-          dotnet tool install -g dotnet-reportgenerator-globaltool
-          reportgenerator \
-            -reports:"coverage/**/coverage.cobertura.xml" \
-            -targetdir:"coverage/report" \
-            -reporttypes:"Cobertura;TextSummary;MarkdownSummaryGithub"
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-${{ github.run_id }}-${{ github.run_attempt }}
-          path: coverage/report
-          retention-days: 14
-
-      - name: Coverage gate
         shell: bash
         run: |
-          line_rate=$(python3 -c "import xml.etree.ElementTree as ET; print(ET.parse('coverage/report/Cobertura.xml').getroot().get('line-rate'))")
-          pct=$(python3 -c "print(round(float('$line_rate') * 100, 1))")
-          echo "Line coverage: ${pct}%  (floor: ${COVERAGE_MIN}%)"
-          echo "### Coverage: ${pct}% (floor ${COVERAGE_MIN}%)" >> "$GITHUB_STEP_SUMMARY"
-          awk "BEGIN { exit !($pct >= $COVERAGE_MIN) }" || {
-            echo "::error::Line coverage ${pct}% is below the floor of ${COVERAGE_MIN}%."
+          shopt -s globstar nullglob
+          found=0
+          for proj in tests/**/*.csproj; do
+            case "$proj" in
+              *AppHost.SmokeTests*|*Infrastructure.IntegrationTests*)
+                echo "::notice::Skipping $proj — owned by its dedicated isolated job."
+                continue ;;
+            esac
+            found=$((found + 1))
+            dotnet test "$proj" -c ${{ inputs.configuration }} --no-build \
+              --collect:"XPlat Code Coverage" \
+              --settings coverlet.runsettings \
+              --results-directory "${{ github.workspace }}/coverage"
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No test projects matched tests/**/*.csproj — the discovery glob is broken."
             exit 1
-          }
+          fi
+          echo "::notice::Ran $found test project(s)."
+
+      # Raw Cobertura only. The merge and the floor now live in
+      # _reusable-coverage-gate.yml, because this job no longer sees every
+      # assembly and gating on a partial report would under-report.
+      - name: Upload raw coverage
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-raw-unit
+          path: coverage/**/coverage.cobertura.xml
+          retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,11 @@
+# ci.yml — leaf: PR gate, and trunk gate until main-ci.yml lands.
+#
+# NOTE for whoever merges main-ci.yml (PR #383): drop the `push: branches:
+# [main]` trigger below in that same PR. main-ci.yml also calls
+# _reusable-build.yml and _reusable-test.yml on push to main, so leaving both
+# triggers active makes every merge run build and test twice. It is kept here
+# only because main-ci.yml is not on main yet and removing it now would leave
+# trunk with no CI at all.
 name: ci
 
 on:
@@ -18,6 +26,7 @@ jobs:
   changes:
     name: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
@@ -30,13 +39,27 @@ jobs:
         id: filter
         shell: bash
         run: |
-            # On push to main / manual dispatch, always run the full pipeline.
-            if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # workflow_dispatch is an explicit human request — always run everything.
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
                 echo "code=true" >> "$GITHUB_OUTPUT"
-                echo "::notice::${{ github.event_name }} event - running full CI."
+                echo "::notice::workflow_dispatch - running full CI."
                 exit 0
             fi
-            base="${{ github.event.pull_request.base.sha }}"
+            # Pick the comparison base: the PR base for PRs, the previous commit
+            # for a push. Previously any non-PR event short-circuited to
+            # code=true, so merging a docs-only PR still paid for the whole
+            # pipeline.
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+                base="${{ github.event.pull_request.base.sha }}"
+            else
+                base="${{ github.event.before }}"
+                # First push to a new branch reports an all-zero "before" SHA.
+                if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+                    echo "code=true" >> "$GITHUB_OUTPUT"
+                    echo "::notice::No usable base SHA - running full CI."
+                    exit 0
+                fi
+            fi
             changed="$(git diff --name-only "$base" HEAD)"
             echo "Changed files:"
             echo "$changed"
@@ -55,11 +78,10 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     uses: ./.github/workflows/_reusable-format.yml
 
-  build:
-    name: build
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    uses: ./.github/workflows/_reusable-build.yml
+  # No `build` job: _reusable-test.yml opens with the identical
+  # `dotnet restore --locked-mode` + `dotnet build -c Release --no-restore`, so a
+  # separate compile gate re-paid for the same work and produced no signal the
+  # test job doesn't already give. _reusable-build.yml is kept for main-ci.yml.
 
   ci:
     name: ci
@@ -78,12 +100,17 @@ jobs:
       actions: read
     uses: ./.github/workflows/_reusable-codeql.yml
 
+  # Owns AppHost.SmokeTests outright — _reusable-test.yml excludes it. Running
+  # it here in isolation, rather than alongside every other assembly on one
+  # runner, is what keeps its Testcontainers port allocation reliable.
+  # `needs: changes` only: it used to wait on `ci`, the very job that had already
+  # run these same tests, which serialized the pipeline for no ordering reason.
   aspire-smoke:
     name: aspire-smoke
-    needs: [changes, ci]
+    needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -110,14 +137,27 @@ jobs:
         run: dotnet build tests/CurrencyTracker.AppHost.SmokeTests --configuration Release --no-restore
 
       - name: Run aspire smoke
-        run: dotnet test tests/CurrencyTracker.AppHost.SmokeTests --configuration Release --no-build
+        run: >
+          dotnet test tests/CurrencyTracker.AppHost.SmokeTests
+          --configuration Release --no-build
+          --collect:"XPlat Code Coverage"
+          --settings coverlet.runsettings
+          --results-directory ${{ github.workspace }}/coverage
 
+      - name: Upload raw coverage
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-raw-aspire-smoke
+          path: coverage/**/coverage.cobertura.xml
+          retention-days: 1
+
+  # Owns Infrastructure.IntegrationTests outright — see the aspire-smoke note.
   infrastructure-integration-tests:
     name: infrastructure-integration-tests
-    needs: [changes, ci]
+    needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -144,7 +184,29 @@ jobs:
         run: dotnet build tests/CurrencyTracker.Infrastructure.IntegrationTests --configuration Release --no-restore
 
       - name: Run integration tests
-        run: dotnet test tests/CurrencyTracker.Infrastructure.IntegrationTests --configuration Release --no-build
+        run: >
+          dotnet test tests/CurrencyTracker.Infrastructure.IntegrationTests
+          --configuration Release --no-build
+          --collect:"XPlat Code Coverage"
+          --settings coverlet.runsettings
+          --results-directory ${{ github.workspace }}/coverage
+
+      - name: Upload raw coverage
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-raw-infra-integration
+          path: coverage/**/coverage.cobertura.xml
+          retention-days: 1
+
+  # The floor is applied here, not inside _reusable-test.yml, because coverage is
+  # now collected across three jobs and no single one of them sees the whole
+  # picture. Gating on a partial report would silently under-report.
+  coverage:
+    name: coverage
+    needs: [changes, ci, aspire-smoke, infrastructure-integration-tests]
+    if: needs.changes.outputs.code == 'true'
+    uses: ./.github/workflows/_reusable-coverage-gate.yml
+    # coverage-min defaults to "58" inside the reusable (13.14 floor).
 
   gitleaks:
     name: gitleaks

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,12 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Creating an issue that is assigned at the same time fires `opened` AND
+# `assigned`, starting two runs a second apart. Collapse them per issue/PR.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude:
     if: |
@@ -18,6 +24,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 30   # without this the job inherits the 360-minute default
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/terraform-pr.yml
+++ b/.github/workflows/terraform-pr.yml
@@ -31,6 +31,7 @@ jobs:
     name: plan-comment
     needs: terraform
     runs-on: ubuntu-latest
+    timeout-minutes: 5   # without this the job inherits the 360-minute default
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
Every test project now runs exactly once per PR, and the container-heavy suites run in isolation instead of competing with every other assembly on one runner.

## What changed

| Change | Why |
|---|---|
| Dropped the `build` job from `ci.yml` | `_reusable-test.yml` opens with the identical `dotnet restore --locked-mode` + `dotnet build -c Release --no-restore`. If compilation breaks, `ci / test` fails at its build step with the same errors. `_reusable-build.yml` is kept for `main-ci.yml`. |
| `_reusable-test.yml` skips the two container suites | They were already being run a second time by `aspire-smoke` and `infrastructure-integration-tests`. |
| `aspire-smoke` / `infrastructure-integration-tests` lose `needs: ci` | They were waiting on the very job that had already run them, which serialized the pipeline for no ordering reason. |
| New `_reusable-coverage-gate.yml` | Coverage is now produced by three jobs, so the floor moved to a job that merges every `coverage-raw-*` artifact first. Gating inside any one job would under-report. |
| `changes` filter now applies to pushes | Previously any non-PR event short-circuited to `code=true`, so a docs-only merge paid for the whole pipeline. |
| `timeout-minutes` + `claude.yml` concurrency + `CODEOWNERS` | Three jobs were inheriting the 360-minute default. An issue opened-and-assigned starts two Claude runs. |

Test discovery is **exclusion-based on purpose**: an include-list would silently drop a newly added test project, which is exactly how the pre-14.28 `has_csharp` gate disabled this pipeline for 350+ PRs. The loop sets `shopt -s globstar` for the same reason.

## Verified locally

- 259 tests across the three simulated jobs (7 projects + 2 isolated), 0 failures.
- 9 raw Cobertura files merged -> **90.6%** line coverage, floor 58%, gate passes.
- All 14 workflow files parse.

## Required before merge

Branch protection currently requires `build / build`, which this PR deletes — the check will never report and the PR cannot merge until the required-checks list is updated:

- remove `build / build`
- add `coverage / coverage` (this is the real gate now)

## Not included

- Removing `ci.yml`'s `push: branches: [main]` trigger. `main-ci.yml` is still in unmerged #383; removing it now would leave trunk with no CI. There is a `NOTE` in `ci.yml` directing whoever merges #383 to drop it there.
- The `terraform-pr.yml` -> `uat-plan` fix for #383. That needs an Azure-side federated credential first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)