### PR TITLE
feat(14.E): secrets, configuration and managed-identity data-plane auth

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -108,7 +108,7 @@ jobs:
     with:
       environment: prod
       image-tag: ${{ github.sha }}
-      strict: false # 14.E flips, with UAT
+      strict: true # ← 14.47, with UAT
       http-smoke: false # internal-LB env: the FQDN is unreachable from a hosted
         # runner, so the verdict is revision health (ADR 0015)
 

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -107,7 +107,7 @@ jobs:
     with:
       environment: uat
       image-tag: ${{ needs.gate.outputs.image-tag }}
-      strict: false # 14.E flips, with the config that makes passing possible
+      strict: true # ← 14.47: config landed; a warned deploy is now a failed deploy
       http-smoke: true
 
   # 14.39 — the reconstruction record is most valuable precisely when something

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,8 @@
         <!-- Determinism -->
         <Deterministic>true</Deterministic>
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'"
-            >true</ContinuousIntegrationBuild>
+            >true</ContinuousIntegrationBuild
+        >
         <!-- Output / repo hygiene -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,8 +13,7 @@
         <!-- Determinism -->
         <Deterministic>true</Deterministic>
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'"
-            >true</ContinuousIntegrationBuild
-        >
+            >true</ContinuousIntegrationBuild>
         <!-- Output / repo hygiene -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,10 @@
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
         <!-- Api -->
         <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+        <!-- Infrastructure (14.45) — Entra token auth + proactive re-auth for
+             Azure Managed Redis. Brings StackExchange.Redis transitively;
+             deliberately the only pin for it. ADR 0017. -->
+        <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
         <!-- Infrastructure -->
         <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
         <!-- Infrastructure, Api -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,9 @@
         <PackageVersion Include="Aspire.Hosting.Seq" Version="13.4.6" />
         <!-- Test -->
         <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.6" />
+        <!-- Infrastructure (14.44) — Entra tokens for the Postgres and Redis
+             data planes. ADR 0017. -->
+        <PackageVersion Include="Azure.Identity" Version="1.21.0" />
         <!-- Test -->
         <PackageVersion Include="coverlet.collector" Version="10.0.1" />
         <!-- Infrastructure -->

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ No schema change is needed — rates are stored by code, not column.
 - `docs/workflow.md` — the eight-step per-issue loop.
 - `docs/prompts.md` — paste-ready prompts for runtimes without an invocation
   mechanism (plain Claude chat, Copilot, Cursor).
+- `docs/configuration.md` — the configuration precedence ladder, what class of
+  value lives where, and why Key Vault is not a layer.
 - `docs/decisions/` — architecture decision records.
 
 ## Licence

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -78,7 +78,45 @@ Two Entra specifics worth knowing:
   value, never a crash). `IsAuthenticated` stays `true`. (If a stable per-user
   GUID is ever needed, Entra's `oid` claim carries it — a future, ADR-worthy
   change to the adapter, not a Phase 11 one.)  
-  
+
+### In Azure (Phase 14.47)
+
+Entra ID is the identity provider for both deployed environments, still by
+configuration only — the authentication pipeline names no provider anywhere, and
+ADR 0010 is intact.
+
+- **`appsettings.Production.json`** declares `Authentication:Provider=EntraId`
+  and nothing else about auth. `Authority` and `Audience` are **not** in the
+  file: they differ per environment and arrive as plain environment variables
+  from `envs/*/terraform.tfvars` (14.43). Putting them in the file would either
+  hardcode one environment's tenant or reintroduce the placeholder problem 14.46
+  refused.
+- **Both Azure environments load that same file.** `ASPNETCORE_ENVIRONMENT` is
+  `Production` in UAT as well as PROD, because UAT exists to rehearse PROD and a
+  UAT that loads a different profile is rehearsing a different application. The
+  cost is that UAT has no OpenAPI explorer, which was already true under
+  `Staging`. See `docs/configuration.md`.
+- **`Provider` is asserted, not branched on.** `AuthenticationProviderGuard`
+  (`src/CurrencyTracker.Api/Security/`) runs at boot: if the declared provider is
+  `EntraId`, the configured authority must be an HTTPS issuer whose path ends in
+  `/v2.0`. That suffix is true of every Entra v2.0 issuer in every cloud
+  (commercial, government, sovereign) and false of every Keycloak realm URL,
+  which ends in `/realms/<name>`; matching on `login.microsoftonline.com` would
+  be narrower for no gain.
+
+  The failure it prevents is otherwise miserable to diagnose. A stale
+  `Authentication__Authority` — a bad merge, a copied environment — would leave
+  the Api booting green, passing `/health/live` and `/health/ready` (neither
+  touches auth), and then rejecting **every** token with a generic
+  issuer-validation failure. With the guard it dies at startup naming both
+  values, the revision never goes healthy, and `strict: true` fails the deploy.
+- **App roles are still required, and are still not automatic.** Expose `user`
+  and `admin` app roles on the API app registration, or every token
+  authenticates and no token authorises. The deploy identity also needs one
+  assigned (plus admin consent) before the authenticated smoke leg can obtain a
+  token — until then `az account get-access-token --resource <audience>` returns
+  `AADSTS500011` and the leg skips.
+
 ## Security posture (Phase 11.12 review)
 
 - **Audience strictly validated.** `ValidateAudience = true`,

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -35,3 +35,46 @@ the **exact** key — never a `KEYS`/`SCAN` pattern sweep (Phase 10.11).
 `GetRateHistoryQuery` (Phase 10.7) is uncached: its key space (base × quote ×
 date range) is large and its per-key reuse is low. A cache earns its keep
 when keys are few and reads repeat.
+
+## In Azure (Phase 14.45)
+
+The adapter above is unchanged. What changed is how the *connection* is made —
+which is the point of the `ICacheService` port: the query slice never noticed.
+
+- **Azure Managed Redis, not Azure Cache for Redis.** The retired product's
+  defaults are inverted here. Access keys are **disabled at creation**
+  (`access_keys_authentication_enabled = false`, an invariant in
+  `modules/redis`), so there is no key path — not even a temporary one — and the
+  first connection the application ever makes must present a Microsoft Entra
+  access token.
+- **Port 10000**, read from the resource by `modules/redis`' output and composed
+  into the connection string by Terraform (14.42). Not 6380. A `6380` anywhere
+  in this repository means something reconstructed a connection string instead
+  of reading the resource.
+- **TLS is set explicitly**, not inferred from the hostname: `client_protocol =
+  "Encrypted"` refuses a plaintext attempt, and being explicit turns that into a
+  readable TLS error rather than a connection reset.
+- **RESP3.** Under RESP2 the client opens a second, subscription connection that
+  the token extension cannot re-authenticate, so the server drops it at every
+  token expiry and the client restores it — harmless, and it emits
+  `MicrosoftEntraTokenExpired` into the cache's error metrics forever.
+- **Authentication is `Microsoft.Azure.StackExchangeRedis`'
+  `ConfigureForAzureWithTokenCredentialAsync`**, which sets the connection user
+  to the identity's object id and installs the re-authentication timer. A raw
+  token in `ConfigurationOptions.Password` is rejected by Managed Redis; that
+  shape is correct only for the retired product. ADR 0017.
+- **`AddStackExchangeRedisCache` is wired through `ConnectionMultiplexerFactory`**
+  in the Azure path, because the extension above is asynchronous and the factory
+  is the only seam that can be awaited. The local path still uses
+  `Configuration` and is byte-for-byte Phase 10's.
+- **Only the Api holds a cache grant.** 14.24's Managed Redis access-policy
+  assignment targets the Api principal alone — the Worker never opens a cache
+  connection, and grants follow code. Both hosts receive
+  `ConnectionStrings__cache` because `AddInfrastructure()` fail-fasts on its
+  absence in either; in the Worker the factory is simply never invoked.
+
+Readiness is what proves all of this: `/health/ready` (Phase 13.B) checks
+Postgres and Redis, so it could not return 200 from Azure until the tokens
+worked. `AbortOnConnectFail = false` changes reconnection behaviour, not command
+behaviour — an operation against an unavailable multiplexer still throws, and
+the readiness check deliberately has no `catch`.

--- a/docs/ci-cd/pipelines.md
+++ b/docs/ci-cd/pipelines.md
@@ -47,7 +47,7 @@ graph LR
   Human[manual dispatch: image-tag] --> U[deploy-uat.yml]
   U --> UG[gate: verify tag exists in ACR]
   UG --> TFU[_reusable-terraform: uat, apply]
-  TFU --> DEPU[_reusable-azure-deploy: uat, strict=false]
+  TFU --> DEPU[_reusable-azure-deploy: uat, strict=true]
   DEPU --> UR[record 90d / notify on failure]
 
   Tag[git tag v*] --> P[deploy-prod.yml]
@@ -230,9 +230,13 @@ internal-LB and unreachable from hosted runners, so its verdict is revision
 health (ADR 0015), which is why `deploy-prod` passes `http-smoke: false`.
 
 1. `GET /health/live` — dependency-free by the 13.B tag contract.
-2. `GET /health/ready` — the dependency probe. Expected to fail until 14.E.
-3. `GET /api/v1/rates/latest?base=USD&target=EUR` with a bearer token — dormant
-   until `SMOKE_TOKEN_RESOURCE` exists (14.E).
+2. `GET /health/ready` — the dependency probe. Passes from 14.45, once both data
+   planes authenticate with Entra tokens.
+3. `GET /api/v1/rates/latest?base=USD&target=EUR` with a bearer token.
+   `SMOKE_TOKEN_RESOURCE` is set from 14.47; the leg still logs a `::notice::`
+   and skips until the API app registration exposes a role assignable to
+   `gh-deploy-uat` (see §Manual prerequisites — `AADSTS500011` is what a missing
+   one looks like).
 
 The third leg asserts the **payload**, not the status code: a 200 with an empty
 body is a load balancer, not a service, and behind a healthy gateway this path
@@ -244,22 +248,31 @@ tooling.
 
 Verdicts follow the strictness ladder below.
 
-## Seams — flipped by 14.E, in the change that makes passing possible
+## Seams — climbed in 14.E
 
 The Api fail-fasts at boot without its connection strings and authority (Phase
-8/11 discipline), so the first real deploys **cannot** be healthy. Pretending
-otherwise would either fake the gate or block the phase. The gate machinery
-lands now; its teeth arrive with the config.
+8/11 discipline), so the deploys 14.D shipped **could not** be healthy. The gate
+machinery landed first with its teeth retracted; 14.E supplied the config and
+flipped each flag in the change that made that rung passable.
 
-| Flag                    | Where                                  | Value now | Meaning                                                                        |
-| ----------------------- | -------------------------------------- | --------- | ------------------------------------------------------------------------------ |
-| `strict`                | deploy leaf → `_reusable-azure-deploy` | `false`   | health gate + smoke warn instead of fail                                        |
-| `health_probes_enabled` | root `main.tf` → app modules           | `false`   | platform probes off (readiness cannot pass without config)                     |
-| `SMOKE_TOKEN_RESOURCE`  | env-scoped variable                    | unset     | authenticated smoke leg dormant                                                |
+| Flag                    | Where                                  | Value now | Flipped in |
+| ----------------------- | -------------------------------------- | --------- | ---------- |
+| `health_probes_enabled` | root `main.tf` → the Api app module    | `true`    | 14.45      |
+| `strict`                | deploy leaf → `_reusable-azure-deploy` | `true`    | 14.47      |
+| `SMOKE_TOKEN_RESOURCE`  | `uat` environment variable             | set       | 14.47      |
 
-A **warned** run is a successful run under this ladder. That distinction matters
-for `notify`, which fires on `failure()` — a red job in `needs` — and therefore
-does not fire on a warnings-only deploy. Do not "improve" it to `!success()`,
+The order is not cosmetic. `health_probes_enabled` waits for 14.45 because
+`/health/ready` checks Postgres *and* Redis, so it could not pass until both
+data planes authenticated; `strict` waits for 14.47 because smoke leg 3 needs an
+Api that trusts Entra. A flag flipped early is a green light that means nothing;
+a flag flipped late is a gate you have stopped believing in.
+
+`health_probes_enabled` is Api-only by construction — the Worker has no ingress,
+no listener, and therefore no probe surface.
+
+A **warned** run is no longer a successful run: with `strict: true` an unhealthy
+revision or a failed smoke leg fails the job, which makes `notify`'s `failure()`
+condition meaningful for the first time. Do not "improve" it to `!success()`,
 which also matches cancelled and skipped chains.
 
 ---
@@ -276,7 +289,8 @@ them can succeed. Record values in [`docs/azure/bootstrap.md`](../azure/bootstra
 | `promotion_pull_principal_id` in `envs/uat/terraform.tfvars` | Terraform    | `deploy-prod` promote    | **pending** |
 | `SLACK_WEBHOOK_URL`                               | repo-level **secret**    | `notify` (both leaves)   | optional |
 | `NOTIFICATIONS_ENABLED`                           | repo-level **variable**  | `notify` kill-switch     | optional |
-| `SMOKE_TOKEN_RESOURCE`                            | `uat` env var            | smoke leg 3              | 14.E   |
+| `SMOKE_TOKEN_RESOURCE`                            | `uat` env var            | smoke leg 3              | 14.47 ✅ |
+| `user` app role on the API app registration, assigned to `gh-deploy-uat` + admin consent | Entra ID | smoke leg 3 | **pending** |
 
 The promotion pair:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,159 @@
+# Configuration
+
+Every environment-varying value in this system arrives through one of five
+layers. Higher wins. There is no sixth, and nothing in `src/` reads a file path,
+a registry key, or a cloud SDK to find configuration.
+
+| # | Layer | Local (Aspire) | Azure (Container Apps) |
+| - | ----- | -------------- | ---------------------- |
+| 1 | Environment variables | Injected by the AppHost (`WithReference`, `WithEnvironment`) | Container App `env` entries — either a literal `value` or a `secretRef` the platform resolved from Key Vault |
+| 2 | User secrets | `dotnet user-secrets` (Development only; the Worker carries a `UserSecretsId`) | n/a |
+| 3 | `appsettings.{Environment}.json` | `appsettings.Development.json` | `appsettings.Production.json` |
+| 4 | `appsettings.json` | shipped defaults | shipped defaults |
+| 5 | Code defaults | `?? "0 0 6 * * ?"`-style fallbacks and options defaults | same |
+
+## Key Vault is not a layer
+
+The Phase 14 build plan phrases the ladder as "env vars > Key Vault > defaults".
+That is one layer too many. A Container App secret with a `keyVaultUrl` is
+resolved **by the platform, using the app's own managed identity, at revision
+start**, and delivered to the process as an ordinary environment variable. By
+the time `IConfiguration` runs there is no Key Vault involved and no way to tell
+a vault-backed variable from a literal one.
+
+Consequences worth knowing:
+
+- You cannot "override Key Vault with an environment variable" — they are the
+  same slot. Declaring both a literal `env` and a `secretRef` with the same name
+  is a platform-level conflict, not an application-level precedence question.
+- A failure to read the vault is a **provisioning** failure
+  (`Field 'configuration.secrets' is invalid … Unable to get value using Managed
+  identity`), not a runtime one. Your code never sees a partial configuration —
+  there is no process yet to see it.
+- The application carries no Key Vault client, no
+  `Azure.Extensions.AspNetCore.Configuration.Secrets`, and no startup vault round
+  trip. It is vault-unaware by design (ADR 0017).
+
+## What goes where
+
+| Class of value | Home | Examples |
+| -------------- | ---- | -------- |
+| Connection strings | **Key Vault**, referenced by the Container App | `ConnectionStrings__currencytracker`, `ConnectionStrings__cache` |
+| Identifiers | Plain environment variables from `envs/*/terraform.tfvars` | `Authentication__Authority`, `Authentication__Audience` |
+| Switches | Plain environment variables, with an explicit default in `appsettings.json` | `Azure__UseManagedIdentity` |
+| Tunables | `appsettings.json`, overridable by environment | `RateLimiting:*`, `SecurityHeaders:*`, `Worker:IngestSchedule` |
+| Credentials | **Key Vault, set out of band** — never through Terraform, which would place the value in state | *(none exist today — see below)* |
+
+This is a rule about a *class* of value, which is why it never needs
+re-adjudicating per value: "everything in the vault" and "nothing in the vault"
+both get refused with the same sentence.
+
+Connection strings live in the vault even though **none of them currently
+contains a credential**: Postgres is Entra-only and Managed Redis has access keys
+disabled (Phase 14.C). A connection string still discloses server name, database
+name and the exact principal to attack — treating it as plain text because it
+happens to lack a password confuses *what a value contains* with *what a value
+discloses*. Consistency also means the first real secret is one map entry rather
+than a new mechanism.
+
+## The secret inventory is empty, and that is a finding
+
+Audited at 14.42 and again at 14.46. The commands, so the next auditor runs the
+same ones:
+
+```powershell
+# Values that look like credentials anywhere in shipped configuration:
+Get-ChildItem -Path src -Recurse -Filter 'appsettings*.json' |
+  Select-String -Pattern '(password|pwd|secret|apikey|api_key|accesskey|connectionstring)\s*[:=]' `
+                -CaseSensitive:$false
+
+# Anything password-shaped in the infrastructure:
+Get-ChildItem -Path infra/terraform -Recurse -Filter '*.tf' |
+  Select-String -Pattern 'administrator_password|access_key|primary_key'
+
+# The same question asked of the deployed surface:
+$rg  = "rg-currencytracker-uat"
+$app = az containerapp list -g $rg --query "[?ends_with(name,'-api')].name | [0]" -o tsv
+az containerapp show -n $app -g $rg --query "properties.configuration.secrets[?value]" -o json
+# [] — no container-app secret carries a literal value; every one is a keyVaultUrl.
+```
+
+The `appsettings` audit returns nothing. The Terraform audit returns three lines,
+and reading them is the point: `access_keys_authentication_enabled = false`
+(`modules/redis`), `shared_access_key_enabled = false` (`modules/storage-logs`)
+and a comment about the same on the state account. Every hit is a credential path
+being *switched off*, which is the opposite of a secret to move.
+
+The rest of the inventory is empty for reasons already on the record:
+`modules/postgres` sets `password_auth_enabled = false` (there is no
+`administrator_login` or `administrator_password` to relocate), `IAlertNotifier`'s
+only adapter writes a structured log line — there is no SMTP anywhere in the
+solution — and the Frankfurter API is public and unauthenticated.
+
+When a real credential does arrive, it does **not** go through Terraform — that
+would place the value in state. Set it out of band with `az keyvault secret set`
+and reference it with a data source or `ignore_changes`. `modules/keyvault`'s
+`secrets` variable says so in its description, because the next person will reach
+for the resource that already exists.
+
+## Placeholders are not used
+
+`appsettings*.json` contains no empty-string placeholders, deliberately. In .NET
+an empty string is a configuration *value*, not an absence: with
+
+```json
+{ "ConnectionStrings": { "currencytracker": "" } }
+```
+
+`IConfiguration.GetConnectionString("currencytracker")` returns `""`, not `null`,
+and every `?? throw` guard in the codebase is a null check. The placeholder
+disarms all of them — the host stops fail-fasting at boot with an actionable
+message and instead fails somewhere downstream, where an `NpgsqlDataSource`
+pointed at nothing surfaces on the first query.
+
+It is worse in local development, where the placeholder wins wherever the
+environment is silent: every test host, every `dotnet run` outside the AppHost,
+every future `dotnet ef` invocation. Those are exactly the cases a fail-fast
+exists for.
+
+So the guards now test `string.IsNullOrWhiteSpace`, not null:
+
+| Guard | Where |
+| ----- | ----- |
+| `currencytracker` connection string | `Infrastructure/Persistence/ApplicationDataSource.cs` (14.44) |
+| `cache` connection string | `Infrastructure/DependencyInjection.cs` (14.45) |
+| `Authentication:Authority` | `Api/Program.cs` (14.46) |
+| `Authentication:Audience` | `Api/Program.cs` (14.46) |
+
+A placeholder added in future therefore still fails fast — but the convention
+stands: **a key the environment supplies does not appear in the file at all.**
+
+`AGENTS.md` carries the same rule as a standing gotcha, with one wrinkle worth
+correcting: it says a connection string in `appsettings.json` would *shadow* the
+Aspire-injected one. Environment variables are added after the JSON providers in
+the default host builder, so an env var actually wins. The conclusion holds for
+the sharper reason above.
+
+## Which profile does each environment load?
+
+Both Azure environments set `ASPNETCORE_ENVIRONMENT` / `DOTNET_ENVIRONMENT` to
+`Production` (14.43), so both load `appsettings.Production.json`. UAT exists to
+rehearse PROD, and a UAT that loads a different configuration file is rehearsing
+a different application. The environments are distinguished by resource group,
+`name_prefix`, state key, ACR, GitHub Environment and OIDC subject — not by a
+profile name. `ASPNETCORE_ENVIRONMENT` distinguishes *behavioural profiles*, and
+this project has exactly two: Development (Scalar UI, migration runner, seeder,
+lax backchannel TLS, Wolverine `Solo` durability) and everything else.
+
+Note that environment-variable names use `__` (double underscore) as the section
+separator: `Azure__UseManagedIdentity`, not `Azure:UseManagedIdentity`. The colon
+form works on Linux only by accident of shell quoting and not at all in a
+Container App `env` entry.
+
+## Related
+
+- `docs/auth.md` — the `Authentication:*` keys and the Entra ID swap.
+- `docs/caching.md` — the cache endpoint and its Entra authentication.
+- `docs/ci-cd/pipelines.md` — where each variable is set, per environment.
+- `docs/decisions/0017-passwordless-azure-data-plane-auth.md`.
+- `docs/decisions/0010-oidc-jwt-auth.md` — why the Api names no identity provider.

--- a/docs/decisions/0017-passwordless-azure-data-plane-auth.md
+++ b/docs/decisions/0017-passwordless-azure-data-plane-auth.md
@@ -1,0 +1,142 @@
+# 0017 — Passwordless Azure data-plane auth: Entra tokens from the workload's own managed identity
+
+- **Status:** Accepted
+- **Date:** 27.07.2026
+- **Authors:** Marco Silva
+- **Supersedes:** —
+- **Related:** 0004-ef-core-persistence.md (the EF Core/Npgsql stack this
+  re-authenticates), 0007-redis-distributed-cache.md (the cache client this
+  re-authenticates), 0014-OIDC-posture.md (the *deploy* identity — a distinct
+  identity set from the workload identities here), 0010-oidc-jwt-auth.md (the
+  *caller's* token — a third, unrelated concern), Phase 14.C (the hardening that
+  removed both passwords), Phase 14.E (14.44/14.45, the client half)
+
+## Context
+
+Phase 14.C created both data planes with their credential paths switched off:
+`modules/postgres` sets `password_auth_enabled = false`, and `modules/redis`
+sets `access_keys_authentication_enabled = false` on Azure Managed Redis from
+birth. There is no password to store and no interim key path to lean on — the
+very first connection either application makes in Azure must present a Microsoft
+Entra access token.
+
+Both wire protocols still expect a password. PostgreSQL has a password message;
+Redis has `AUTH`. "Passwordless" therefore does not mean a missing credential —
+it means a short-lived token, fetched from the instance metadata endpoint and
+scoped to the target resource, is what goes in the password slot. Because tokens
+expire in roughly an hour and a connection pool outlives them, both clients need
+a refresh story.
+
+Two vendor extensions exist for exactly this, and the alternative is hand-rolled
+token caching in two places.
+
+## Decision
+
+- **The application authenticates to its Azure data planes with Entra tokens
+  acquired from its own system-assigned managed identity**, gated by one
+  configuration switch, `Azure:UseManagedIdentity`, supplied in Azure as the
+  `Azure__UseManagedIdentity` environment variable (14.43) and defaulted to
+  `false` in `appsettings.json`.
+- **Two new top-level packages, both referenced by `Infrastructure` only:**
+  - `Azure.Identity` (14.44) — `TokenCredential` and its internal token cache.
+  - `Microsoft.Azure.StackExchangeRedis` (14.45) — the token extension for
+    Azure Managed Redis, including proactive re-authentication before expiry.
+- **`TokenCredential` is the abstraction; no port is introduced.** No
+  `ISecretProvider`, no `ITokenSource`, no `IConnectionFactory` in Application.
+  The Azure SDK ships an abstract class with a test-friendly surface, and a
+  nine-line in-memory fake covers the tests.
+- **Postgres: `NpgsqlDataSourceBuilder.UsePasswordProvider`, both delegates.**
+  `ApplicationDataSource.Create` attaches a synchronous *and* an asynchronous
+  provider scoped to `https://ossrdbms-aad.database.windows.net/.default`. The
+  synchronous one is implemented rather than throwing — see Consequences.
+- **Redis: `ConfigureForAzureWithTokenCredentialAsync` behind
+  `RedisCacheOptions.ConnectionMultiplexerFactory`.** The extension is
+  asynchronous, and the factory is the only `AddStackExchangeRedisCache` seam
+  that can be awaited. Options are shaped for Azure Managed Redis: TLS on,
+  RESP3, and the port read from the resource (10000, not the retired product's
+  6380).
+- **`DefaultAzureCredential`, not `ManagedIdentityCredential`.** The chain costs
+  a few hundred milliseconds once and buys the ability to run a host locally,
+  `az login`-ed, against real UAT infrastructure — the diagnostic you want the
+  first time a deployed revision cannot connect.
+- **The application stays vault-unaware.** No Key Vault configuration provider,
+  no vault client. Container Apps resolves secret references before the process
+  starts (see `docs/configuration.md`).
+
+## Considered and rejected
+
+- **`UsePeriodicPasswordProvider` with a fixed refresh interval.** The older
+  Npgsql API. It adds a second cache in front of the one already inside
+  `Azure.Identity`, with a hardcoded interval free to drift from the real token
+  lifetime. Npgsql's documentation now leads with `UsePasswordProvider` for
+  precisely the cloud-provider-caches case. Rejected.
+- **A hand-rolled `AccessToken` field with a `DateTimeOffset` expiry check.**
+  Same defect, written by us, and the refresh timer is where the bugs live.
+  Rejected.
+- **Throwing `NotSupportedException` from the synchronous password provider**,
+  as the Npgsql documentation suggests. Sound advice for connections you open
+  yourself; this codebase hands the same data source to Wolverine's durability
+  subsystem, which owns connection lifecycles, leader election and heartbeat
+  agents that this project does not control. Rejected — the bet's downside is a
+  `NotSupportedException` at 3am.
+- **`ManagedIdentityCredential`.** Faster and less chatty in a container, and it
+  cannot authenticate a developer. Rejected for now; narrowing to it later is a
+  one-line change with a known cost.
+- **`options.Password = token` for Redis.** The correct answer for the *retired*
+  Azure Cache for Redis and the single most likely wrong turn here. Azure Managed
+  Redis rejects a raw token in the password slot; the extension sets the
+  connection user to the identity's object id and installs re-authentication.
+  Rejected because it does not work.
+- **RESP2 (the default protocol).** Opens a second, subscription connection that
+  cannot be re-authenticated, so the server drops it at every token expiry and
+  the client restores it. Functionally fine; it emits `MicrosoftEntraTokenExpired`
+  into the cache's error metrics forever, which trains you to ignore the metric
+  14.52 will alert on. Rejected for one line of configuration.
+- **An in-process Key Vault configuration provider
+  (`Azure.Extensions.AspNetCore.Configuration.Secrets`).** A legitimate pattern,
+  and a second path to a value the platform already resolved — plus a startup
+  round trip and a credential chain to debug on a laptop. Rejected; the platform
+  path wins because it fails *before* the process exists.
+- **A separate `StackExchange.Redis` version pin.** `ConfigurationOptions`,
+  `RedisProtocol` and `ConnectionMultiplexer` arrive transitively, as they have
+  since Phase 10 via `Microsoft.Extensions.Caching.StackExchangeRedis`. Pinning
+  both creates a compatibility pair to maintain by hand. Rejected.
+
+## Consequences
+
+- **No credential exists at rest anywhere in the system.** Nothing to rotate,
+  nothing to leak, nothing for `gitleaks` to find. A stolen token is useless in
+  about an hour.
+- **Both hosts share one authentication implementation.** `ApplicationDataSource`
+  has two callers — EF Core's registration and the Worker's Wolverine outbox —
+  and is still a static factory, because two *calls* are not two *concepts*.
+- **The synchronous provider is load-bearing, not defensive.** Removing it
+  converts any synchronous connection open inside Wolverine's durability
+  subsystem into a hard failure. Keep both delegates.
+- **The local path is untouched.** With the switch off, the connection string is
+  used exactly as supplied and the cache registration is byte-for-byte Phase
+  10's. Aspire, the Testcontainers suites and the AppHost smoke tests needed no
+  edits, which is the regression evidence that matters.
+- **Two packages, one layer.** `Api` and `Worker` gained no package references;
+  both reach Azure through `AddInfrastructure()`. The dependency-direction test
+  in `Architecture.Tests` is unaffected — it inspects project references.
+- **`DefaultAzureCredential` resolves a different principal locally than in the
+  container.** "It works on my machine against real UAT" proves your Entra
+  account is a Postgres administrator, not that the app's identity is. Check
+  `az account show --query user.name` when interpreting a local success.
+- **Verify what NuGet actually resolved** for the transitive
+  `StackExchange.Redis` before merging a version bump:
+  `dotnet list src/CurrencyTracker.Infrastructure package --include-transitive`.
+
+## Notes
+
+- The grants these tokens exercise are not in this ADR: the Postgres Entra
+  administrator registrations and the Managed Redis access-policy assignment
+  live in `infra/terraform/modules/role-assignments` (14.24), which is
+  deliberately readable top to bottom as the least-privilege ledger.
+- The Redis grant is **Api-only**, on purpose — the Worker never opens a cache
+  connection. `ConnectionMultiplexerFactory`'s laziness is what makes that
+  asymmetry survivable rather than a boot failure in the Worker.
+- Package versions are pinned in `Directory.Packages.props`; a `Version=`
+  attribute in a `.csproj` is a Central Package Management violation the build
+  will not catch for you.

--- a/infra/terraform/envs/prod/terraform.tfvars
+++ b/infra/terraform/envs/prod/terraform.tfvars
@@ -30,3 +30,18 @@ postgres_sku_name = "GP_Standard_D2s_v3"
 # to imply — the SKU string no longer encodes it.
 redis_sku_name                  = "Balanced_B1"
 redis_high_availability_enabled = true
+
+# 14.43 — Entra ID as the Api's identity provider. Identifiers, not secrets;
+# see the UAT envelope for the full reasoning.
+#
+# REVIEW BEFORE THE FIRST PROD APPLY, like the Redis SKU above. These are the
+# SAME tenant and the SAME app registration UAT uses, because only one API app
+# registration exists today (docs/azure/bootstrap.md §App Registrations lists
+# the deploy identities, not this one). Sharing an audience across environments
+# means a UAT-issued token is accepted by PROD. That is tolerable while PROD has
+# never been applied and holds no data; it is not a steady state. When a
+# prod-only registration exists, this file is the only thing that changes — the
+# split costs two lines here and nothing in code, which is the whole point of
+# ADR 0010's config-only provider swap.
+api_authentication_authority = "https://login.microsoftonline.com/04b94fa0-2449-42e3-b19d-3275d586556a/v2.0" # gitleaks:allow
+api_authentication_audience  = "e50b769e-1b9e-487d-baf5-7108f98935f2"                                        # gitleaks:allow

--- a/infra/terraform/envs/uat/terraform.tfvars
+++ b/infra/terraform/envs/uat/terraform.tfvars
@@ -30,6 +30,24 @@ postgres_sku_name = "B_Standard_B1ms"
 # the retired Basic/C0 it replaces; there is no cheaper AMR option.
 redis_sku_name                  = "Balanced_B0"
 redis_high_availability_enabled = false
+# 14.43 — Entra ID is the Api's identity provider in Azure (14.47). Both values
+# are IDENTIFIERS, not secrets: the authority appears in every token this API
+# validates, and the audience is an app registration's client id. They arrive as
+# plain env vars, never as Key Vault references — a vault read per revision start
+# to conceal a value printed in every JWT would be ceremony, not security.
+#
+# Register the `user` and `admin` APP ROLES on this app registration, or every
+# token authenticates and no token authorises (docs/auth.md). The audience is
+# also what SMOKE_TOKEN_RESOURCE must be set to on the uat environment (14.47).
+#
+# gitleaks reads both lines as generic-api-key on shape alone. They are not:
+# the first is a public OIDC issuer URL, the second an app-registration client
+# id, and both already sit in src/CurrencyTracker.Api/appsettings.Azure.json.
+# Allowed inline rather than repo-wide, so the next value that trips the rule
+# still has to be argued.
+api_authentication_authority = "https://login.microsoftonline.com/04b94fa0-2449-42e3-b19d-3275d586556a/v2.0" # gitleaks:allow
+api_authentication_audience  = "e50b769e-1b9e-487d-baf5-7108f98935f2"                                        # gitleaks:allow
+
 # 14.37 — gh-deploy-prod's SERVICE PRINCIPAL object id: the read-only promotion
 # path into this environment's ACR (az acr import by digest). An object id is an
 # identifier, not a secret. Populate with:

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -182,6 +182,14 @@ module "container_app_api" {
   # problem. Reaches UAT via a deploy-uat dispatch; PROD on its first apply.
   use_acr_registry = true
 
+  # 14.45 — the platform probes come on now, and not one issue earlier. They
+  # target /health/live and /health/ready (Phase 13.B); readiness checks
+  # Postgres AND Redis, so it could not have passed before 14.44 and 14.45
+  # landed. Arming a probe against an endpoint that cannot succeed is how you
+  # teach a team to ignore a red probe. The Worker has no ingress, no listener
+  # and therefore no probe surface — this is Api-only by construction.
+  health_probes_enabled = true
+
   # 14.43 — container-app secrets, resolved from Key Vault by THIS app's own
   # system identity while the revision provisions. Terraform passes the URI;
   # the value never enters an output, a workflow log, or this state file.

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -182,8 +182,45 @@ module "container_app_api" {
   # problem. Reaches UAT via a deploy-uat dispatch; PROD on its first apply.
   use_acr_registry = true
 
+  # 14.43 — container-app secrets, resolved from Key Vault by THIS app's own
+  # system identity while the revision provisions. Terraform passes the URI;
+  # the value never enters an output, a workflow log, or this state file.
+  #
+  # FRESH ENVIRONMENT: leave this map empty for the first apply. The identity
+  # is minted by this resource and 14.24's Key Vault Secrets User grant needs
+  # it, so on a first apply the reference resolves before the grant exists and
+  # the revision fails with "Unable to get value using Managed identity".
+  # Apply once empty, then again populated — the same bootstrap ordering as
+  # use_acr_registry, and the reason PROD's first apply is two passes.
+  key_vault_secrets = {
+    "connectionstrings-currencytracker" = module.keyvault.secret_versionless_ids["api-connectionstrings-currencytracker"]
+    "connectionstrings-cache"           = module.keyvault.secret_versionless_ids["connectionstrings-cache"]
+  }
+
+  # The env var names are the double-underscore form of the configuration keys
+  # Phase 8 and Phase 10 read: ConnectionStrings:currencytracker and :cache.
+  # The container-app secret names are deliberately identical across both apps
+  # even though the vault secrets differ — the app-side name is the app's
+  # contract, the vault-side name is the vault's inventory.
+  secret_env_vars = {
+    "ConnectionStrings__currencytracker" = "connectionstrings-currencytracker"
+    "ConnectionStrings__cache"           = "connectionstrings-cache"
+  }
+
+  # Non-secret configuration: identifiers and switches only.
   env_vars = {
-    ASPNETCORE_ENVIRONMENT = var.environment == "prod" ? "Production" : "Staging"
+    # 14.47 collapses the UAT/PROD split — UAT rehearses PROD, so it loads the
+    # same appsettings profile. The environments differ by resource group,
+    # name_prefix, state key, ACR and OIDC subject, not by profile name.
+    ASPNETCORE_ENVIRONMENT = "Production"
+
+    # 14.44/14.45 read this. It ships ahead of the code that consumes it: an
+    # env var nothing reads is inert, whereas code reading a missing var is a
+    # boot failure. Config before code is the safe ordering.
+    Azure__UseManagedIdentity = "true"
+
+    Authentication__Authority = var.api_authentication_authority
+    Authentication__Audience  = var.api_authentication_audience
   }
 
   tags = local.common_tags
@@ -202,8 +239,26 @@ module "container_app_worker" {
   # 14.35: same flip as the Api — see that block's note.
   use_acr_registry = true
 
+  # 14.43 — same shape as the Api, different Postgres role: the Worker
+  # authenticates as ca-worker-identity. The cache secret is here because
+  # AddInfrastructure() fail-fasts on a missing ConnectionStrings__cache in
+  # BOTH hosts — but the Worker holds no Redis grant (14.24 is Api-only,
+  # deliberately) and never opens a cache connection, so the value is present
+  # and never used. 14.45's lazy ConnectionMultiplexerFactory is what makes
+  # that asymmetry survivable rather than a boot failure.
+  key_vault_secrets = {
+    "connectionstrings-currencytracker" = module.keyvault.secret_versionless_ids["worker-connectionstrings-currencytracker"]
+    "connectionstrings-cache"           = module.keyvault.secret_versionless_ids["connectionstrings-cache"]
+  }
+
+  secret_env_vars = {
+    "ConnectionStrings__currencytracker" = "connectionstrings-currencytracker"
+    "ConnectionStrings__cache"           = "connectionstrings-cache"
+  }
+
   env_vars = {
-    DOTNET_ENVIRONMENT = var.environment == "prod" ? "Production" : "Staging"
+    DOTNET_ENVIRONMENT        = "Production"
+    Azure__UseManagedIdentity = "true"
   }
 
   tags = local.common_tags

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -56,6 +56,16 @@ variable "redis_high_availability_enabled" {
   description = "Whether the cache runs a replica for its SLA (true in PROD). Mirrors postgres_zone_redundant: PROD buys resilience, UAT buys the lower bill."
   type        = bool
 }
+variable "api_authentication_authority" {
+  description = "OIDC issuer the Api validates tokens against, e.g. https://login.microsoftonline.com/<tenant-id>/v2.0. An identifier, not a secret — same posture as the 14.A AZURE_* GitHub variables, and it appears in every token this API validates anyway. Arrives at the container as Authentication__Authority. 14.47's boot-time guard asserts it agrees with the declared provider, so a stale value here kills the revision instead of 401ing every request."
+  type        = string
+}
+
+variable "api_authentication_audience" {
+  description = "Audience the Api requires in a token — the API app registration's client id (or api://<client-id>). An identifier, not a secret. Arrives as Authentication__Audience, and is the same value SMOKE_TOKEN_RESOURCE carries on the uat GitHub environment (14.47)."
+  type        = string
+}
+
 variable "promotion_pull_principal_id" {
   description = "Object ID of gh-deploy-prod, granted AcrPull on this env's ACR for release promotion (az acr import by digest). Set in the UAT envelope only; null in PROD. See modules/role-assignments and docs/ci-cd/pipelines.md."
   type        = string

--- a/src/CurrencyTracker.Api/Program.cs
+++ b/src/CurrencyTracker.Api/Program.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using CurrencyTracker.Api;
 using CurrencyTracker.Api.ErrorHandling;
 using CurrencyTracker.Api.Health;
+using CurrencyTracker.Api.Security; // AuthenticationProviderGuard (14.47)
 using CurrencyTracker.Application;
 using CurrencyTracker.Application.Abstractions.Notifications;
 using CurrencyTracker.Application.Abstractions.Persistence;
@@ -106,6 +107,17 @@ if (string.IsNullOrWhiteSpace(authAudience))
             + "integration tests) must set it explicitly."
     );
 }
+
+// 14.47 — the declared provider must agree with the authority we were handed.
+// Not a provider switch (ADR 0010): the pipeline below still names no IdP. This
+// is what stops Authentication:Provider from being decorative — without it a
+// stale authority boots green, passes both health probes, and then rejects
+// every token with a generic issuer-validation failure.
+AuthenticationProviderGuard.Validate(
+    builder.Configuration["Authentication:Provider"],
+    authAuthority
+);
+
 builder
     .Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>

--- a/src/CurrencyTracker.Api/Program.cs
+++ b/src/CurrencyTracker.Api/Program.cs
@@ -79,20 +79,33 @@ builder.Services.AddProblemDetails(options =>
 // what a `?? throw` inside the AddJwtBearer callback would do. Mirrors the
 // connection-string fail-fast in AddInfrastructure. (Audience is read in 11.5,
 // where it's first consumed, so its own fail-fast lands there.)
-var authAuthority =
-    builder.Configuration["Authentication:Authority"]
-    ?? throw new InvalidOperationException(
+// 14.46: IsNullOrWhiteSpace, not null. An empty string is a configuration
+// VALUE in .NET, so an appsettings "placeholder" would satisfy a null check and
+// disarm these guards — the Api would then boot green and reject every token at
+// request time. See docs/configuration.md.
+var authAuthority = builder.Configuration["Authentication:Authority"];
+
+if (string.IsNullOrWhiteSpace(authAuthority))
+{
+    throw new InvalidOperationException(
         "Authentication:Authority is not configured. The AppHost injects it as "
-            + "Authentication__Authority (Phase 11.3); non-Aspire hosts (including "
+            + "Authentication__Authority (Phase 11.3); Azure supplies it as a plain "
+            + "environment variable (Phase 14.43); non-Aspire hosts (including "
             + "integration tests) must set it explicitly."
     );
-var authAudience =
-    builder.Configuration["Authentication:Audience"]
-    ?? throw new InvalidOperationException(
+}
+
+var authAudience = builder.Configuration["Authentication:Audience"];
+
+if (string.IsNullOrWhiteSpace(authAudience))
+{
+    throw new InvalidOperationException(
         "Authentication:Audience is not configured. The AppHost injects it as "
-            + "Authentication__Audience (Phase 11.3); non-Aspire hosts (including "
+            + "Authentication__Audience (Phase 11.3); Azure supplies it as a plain "
+            + "environment variable (Phase 14.43); non-Aspire hosts (including "
             + "integration tests) must set it explicitly."
     );
+}
 builder
     .Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>

--- a/src/CurrencyTracker.Api/Security/AuthenticationProviderGuard.cs
+++ b/src/CurrencyTracker.Api/Security/AuthenticationProviderGuard.cs
@@ -1,0 +1,76 @@
+namespace CurrencyTracker.Api.Security;
+
+/// <summary>
+/// Boot-time assertion that the identity provider a deployment <i>declares</i>
+/// agrees with the authority it was actually given.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is deliberately not a provider switch. Per ADR 0010 the Api is
+/// IdP-agnostic: it validates whatever <c>Authentication:Authority</c> and
+/// <c>Authentication:Audience</c> point at, and never names a provider in the
+/// authentication pipeline. Branching on <c>Authentication:Provider</c> would
+/// put knowledge of two specific identity providers back into the composition
+/// root and make "config-only provider swap" false the day it was written down
+/// as true.
+/// </para>
+/// <para>
+/// The key still has to earn its keep, though: a declaration nothing reads is
+/// worse than an absent one, because it looks authoritative. So it is asserted
+/// rather than branched on. A stale <c>Authentication__Authority</c> against a
+/// declared provider would otherwise boot green, pass <c>/health/live</c>, pass
+/// <c>/health/ready</c> — neither touches auth — and then reject every token at
+/// request time with a generic issuer-validation failure.
+/// </para>
+/// </remarks>
+internal static class AuthenticationProviderGuard
+{
+    /// <summary>Declared-provider value meaning Microsoft Entra ID.</summary>
+    private const string EntraId = "EntraId";
+
+    /// <summary>
+    /// The one property that distinguishes an Entra ID v2.0 issuer from a
+    /// Keycloak realm, in every cloud. Matching on the host name
+    /// (<c>login.microsoftonline.com</c>) would be narrower and would break in
+    /// sovereign clouds for no benefit; every Keycloak authority ends in
+    /// <c>/realms/&lt;name&gt;</c>.
+    /// </summary>
+    private const string EntraIssuerSuffix = "/v2.0";
+
+    /// <summary>
+    /// Throws when the declared provider and the configured authority disagree.
+    /// </summary>
+    /// <param name="provider">
+    /// Value of <c>Authentication:Provider</c>, or <c>null</c> when the
+    /// deployment declares nothing (local development, integration tests).
+    /// </param>
+    /// <param name="authority">The configured OIDC authority.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="provider"/> is <c>EntraId</c> and
+    /// <paramref name="authority"/> is not an HTTPS Entra ID v2.0 issuer.
+    /// </exception>
+    public static void Validate(string? provider, string authority)
+    {
+        if (!string.Equals(provider, EntraId, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var isEntraIssuer =
+            Uri.TryCreate(authority, UriKind.Absolute, out var uri)
+            && uri.Scheme == Uri.UriSchemeHttps
+            && uri.AbsolutePath.EndsWith(EntraIssuerSuffix, StringComparison.Ordinal);
+
+        if (!isEntraIssuer)
+        {
+            throw new InvalidOperationException(
+                $"Authentication:Provider is '{EntraId}', but Authentication:Authority "
+                    + $"is '{authority}', which is not an HTTPS Microsoft Entra ID v2.0 "
+                    + "issuer (expected a path ending in '/v2.0'). Either the deployment's "
+                    + "Authentication__Authority environment variable is stale (see "
+                    + "infra/terraform/envs/*/terraform.tfvars) or this host is running the "
+                    + "wrong appsettings profile."
+            );
+        }
+    }
+}

--- a/src/CurrencyTracker.Api/appsettings.Azure.json
+++ b/src/CurrencyTracker.Api/appsettings.Azure.json
@@ -1,5 +1,6 @@
 {
   "Authentication": {
+    "Provider": "EntraId",
     "Authority": "https://login.microsoftonline.com/04b94fa0-2449-42e3-b19d-3275d586556a/v2.0",
     "Audience": "e50b769e-1b9e-487d-baf5-7108f98935f2"
   }

--- a/src/CurrencyTracker.Api/appsettings.Production.json
+++ b/src/CurrencyTracker.Api/appsettings.Production.json
@@ -1,0 +1,14 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft.EntityFrameworkCore": "Warning"
+      }
+    }
+  },
+  "Authentication": {
+    "Provider": "EntraId"
+  }
+}

--- a/src/CurrencyTracker.Api/appsettings.json
+++ b/src/CurrencyTracker.Api/appsettings.json
@@ -7,6 +7,9 @@
       }
     }
   },
+  "Azure": {
+    "UseManagedIdentity": false
+  },
   "Frankfurter": {
     "BaseUrl": "https://api.frankfurter.dev",
     "Timeout": "00:00:10",

--- a/src/CurrencyTracker.Infrastructure/Caching/CacheConnection.cs
+++ b/src/CurrencyTracker.Infrastructure/Caching/CacheConnection.cs
@@ -1,0 +1,110 @@
+using Azure.Core;
+using Azure.Identity;
+using Microsoft.Azure.StackExchangeRedis;
+using StackExchange.Redis;
+
+namespace CurrencyTracker.Infrastructure.Caching;
+
+/// <summary>
+/// Builds the cache connection for the current environment. Locally the
+/// endpoint is a plaintext Aspire container; in Azure it is Azure Managed
+/// Redis, which has <b>no access-key path at all</b> (14.C disabled key
+/// authentication at creation) and listens on port 10000 rather than the 6380
+/// the retired Azure Cache for Redis used.
+/// </summary>
+/// <remarks>
+/// Nothing here reads configuration. The Entra switch is declared once, on
+/// <see cref="Persistence.ApplicationDataSource.ManagedIdentityKey"/>, and read
+/// once in <see cref="DependencyInjection"/>. One key, one declaration, two
+/// consumers.
+/// </remarks>
+public static class CacheConnection
+{
+    /// <summary>
+    /// Name of the cache connection string. Aspire injects it locally as
+    /// <c>ConnectionStrings__cache</c> (Phase 7.5); Container Apps resolves it
+    /// from Key Vault under the same name (14.43). In Azure the value is a bare
+    /// <c>host:port</c> — there is no credential to carry.
+    /// </summary>
+    public const string ConnectionStringName = "cache";
+
+    /// <summary>
+    /// Shapes the connection options for an endpoint.
+    /// </summary>
+    /// <param name="endpoint">Endpoint in <c>host:port</c> form.</param>
+    /// <param name="useManagedIdentity">
+    /// When <c>true</c>, apply the Azure Managed Redis posture: TLS required and
+    /// RESP3 selected.
+    /// </param>
+    /// <returns>Options ready for authentication and connection.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="endpoint"/> is null, empty or whitespace.
+    /// </exception>
+    public static ConfigurationOptions BuildOptions(string endpoint, bool useManagedIdentity)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(endpoint);
+
+        var options = ConfigurationOptions.Parse(endpoint);
+
+        if (!useManagedIdentity)
+        {
+            return options;
+        }
+
+        // Explicit rather than inferred from the hostname: modules/redis pins
+        // client_protocol = "Encrypted", so a plaintext attempt is refused, and
+        // being explicit turns that into a readable TLS error rather than a
+        // connection reset.
+        options.Ssl = true;
+
+        // RESP3 puts interactive and pub/sub traffic on ONE connection, which
+        // the token extension can proactively re-authenticate. Under RESP2 the
+        // separate subscription connection cannot be re-authenticated: the
+        // server drops it at every token expiry and the client restores it —
+        // harmless, and it emits MicrosoftEntraTokenExpired into the cache's
+        // error metrics forever, which is the metric 14.52 will alert on.
+        options.Protocol = RedisProtocol.Resp3;
+
+        // The multiplexer is created lazily, on first cache use. Aborting on a
+        // transient first-connect failure would leave a permanently dead
+        // multiplexer; false lets it reconnect in the background. This does not
+        // hide a broken cache from readiness — an operation against an
+        // unavailable multiplexer still throws, and the Phase 13.B check has no
+        // catch, so it still reports Unhealthy.
+        options.AbortOnConnectFail = false;
+
+        return options;
+    }
+
+    /// <summary>
+    /// Connects to the cache, authenticating with Microsoft Entra when
+    /// <paramref name="useManagedIdentity"/> is set.
+    /// </summary>
+    /// <param name="endpoint">Endpoint in <c>host:port</c> form.</param>
+    /// <param name="useManagedIdentity">Whether to authenticate with Entra.</param>
+    /// <param name="credential">
+    /// Credential used to acquire Entra tokens. Defaults to
+    /// <see cref="DefaultAzureCredential"/>. Injected only by tests.
+    /// </param>
+    /// <returns>A connected multiplexer.</returns>
+    public static async Task<IConnectionMultiplexer> ConnectAsync(
+        string endpoint,
+        bool useManagedIdentity,
+        TokenCredential? credential = null
+    )
+    {
+        var options = BuildOptions(endpoint, useManagedIdentity);
+
+        if (useManagedIdentity)
+        {
+            // Sets the connection user to the identity's object id and installs
+            // the re-authentication timer. Azure Managed Redis rejects a raw
+            // token placed in Password — this extension is the supported path.
+            await options.ConfigureForAzureWithTokenCredentialAsync(
+                credential ?? new DefaultAzureCredential()
+            );
+        }
+
+        return await ConnectionMultiplexer.ConnectAsync(options);
+    }
+}

--- a/src/CurrencyTracker.Infrastructure/CurrencyTracker.Infrastructure.csproj
+++ b/src/CurrencyTracker.Infrastructure/CurrencyTracker.Infrastructure.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="Azure.Identity" />
         <PackageReference Include="EFCore.NamingConventions" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
+        <PackageReference Include="Microsoft.Azure.StackExchangeRedis" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" />

--- a/src/CurrencyTracker.Infrastructure/CurrencyTracker.Infrastructure.csproj
+++ b/src/CurrencyTracker.Infrastructure/CurrencyTracker.Infrastructure.csproj
@@ -15,6 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Azure.Identity" />
         <PackageReference Include="EFCore.NamingConventions" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" />

--- a/src/CurrencyTracker.Infrastructure/DependencyInjection.cs
+++ b/src/CurrencyTracker.Infrastructure/DependencyInjection.cs
@@ -42,15 +42,16 @@ public static class DependencyInjection
     /// </exception>
     public static IHostApplicationBuilder AddInfrastructure(this IHostApplicationBuilder builder)
     {
-        var connectionString =
-            builder.Configuration.GetConnectionString("currencytracker")
-            ?? throw new InvalidOperationException(
-                "The 'currencytracker' connection string is not configured. "
-                    + "Are you running through the Aspire AppHost?"
-            );
+        // 14.44 — one data source for the whole host, and the only place the
+        // connection string is read. Registered as a singleton so the container
+        // disposes it at shutdown: UseNpgsql(DbDataSource) treats the instance
+        // as externally owned and will not dispose it. In Azure this carries an
+        // Entra token password provider; locally it is Aspire's string, as-is.
+        var dataSource = ApplicationDataSource.Create(builder.Configuration);
+        builder.Services.AddSingleton(dataSource);
 
         builder.Services.AddDbContext<ApplicationDbContext>(options =>
-            options.UseNpgsql(connectionString).UseSnakeCaseNamingConvention()
+            options.UseNpgsql(dataSource).UseSnakeCaseNamingConvention()
         );
 
         // Redis distributed cache. The connection string is injected by the

--- a/src/CurrencyTracker.Infrastructure/DependencyInjection.cs
+++ b/src/CurrencyTracker.Infrastructure/DependencyInjection.cs
@@ -54,19 +54,50 @@ public static class DependencyInjection
             options.UseNpgsql(dataSource).UseSnakeCaseNamingConvention()
         );
 
-        // Redis distributed cache. The connection string is injected by the
-        // AppHost via WithReference(cache) (Phase 7.5) as ConnectionStrings__cache.
-        // Fail fast if it's absent — same discipline as the Postgres connection
-        // string in Phase 8. Never hardcode "localhost:6379".
-        var cacheConnection =
-            builder.Configuration.GetConnectionString("cache")
-            ?? throw new InvalidOperationException(
-                "ConnectionStrings__cache is not configured. Run via the AppHost "
-                    + "(WithReference(cache), Phase 7.5) so the connection string is injected."
-            );
-        builder.Services.AddStackExchangeRedisCache(options =>
-            options.Configuration = cacheConnection
+        // 14.45 — Redis distributed cache. Locally the endpoint is Aspire's
+        // plaintext container (WithReference(cache), Phase 7.5) and the
+        // connection string is used as-is. In Azure it is Managed Redis with
+        // access keys disabled, so the connection must present an Entra token
+        // from its FIRST attempt — hence the async factory below: the token
+        // extension is awaitable and the cache invokes the factory lazily, once.
+        //
+        // Never hardcode "localhost:6379". IsNullOrWhiteSpace, not null: an
+        // empty string is a configuration value (14.46, docs/configuration.md).
+        var cacheEndpoint = builder.Configuration.GetConnectionString(
+            CacheConnection.ConnectionStringName
         );
+
+        if (string.IsNullOrWhiteSpace(cacheEndpoint))
+        {
+            throw new InvalidOperationException(
+                $"ConnectionStrings__{CacheConnection.ConnectionStringName} is not configured. "
+                    + "Locally it is injected by the Aspire AppHost (WithReference(cache), "
+                    + "Phase 7.5); in Azure it is a Key Vault reference (Phase 14.43)."
+            );
+        }
+
+        var useManagedIdentity = builder.Configuration.GetValue<bool>(
+            ApplicationDataSource.ManagedIdentityKey
+        );
+
+        if (useManagedIdentity)
+        {
+            // The Worker never opens a cache connection — 14.24 grants the
+            // Managed Redis access policy to the Api ONLY, deliberately, because
+            // grants follow code. This factory's laziness is what makes that
+            // asymmetry survivable rather than a boot failure in the Worker.
+            builder.Services.AddStackExchangeRedisCache(options =>
+                options.ConnectionMultiplexerFactory = () =>
+                    CacheConnection.ConnectAsync(cacheEndpoint, useManagedIdentity: true)
+            );
+        }
+        else
+        {
+            builder.Services.AddStackExchangeRedisCache(options =>
+                options.Configuration = cacheEndpoint
+            );
+        }
+
         builder.Services.AddSingleton<ICacheService, RedisCacheService>();
 
         builder

--- a/src/CurrencyTracker.Infrastructure/Persistence/ApplicationDataSource.cs
+++ b/src/CurrencyTracker.Infrastructure/Persistence/ApplicationDataSource.cs
@@ -1,0 +1,142 @@
+using Azure.Core;
+using Azure.Identity;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+
+namespace CurrencyTracker.Infrastructure.Persistence;
+
+/// <summary>
+/// Factory for the application's <see cref="NpgsqlDataSource"/>. Two callers:
+/// the EF Core registration in <see cref="DependencyInjection"/>, and the
+/// Worker's Wolverine outbox. Both need the same authentication behaviour, so
+/// the token logic is written once, here.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When <c>Azure:UseManagedIdentity</c> is <c>false</c> (local, Aspire, tests)
+/// the connection string is used exactly as supplied. When it is <c>true</c>, a
+/// password provider attaches: Azure Database for PostgreSQL accepts a Microsoft
+/// Entra access token where the PostgreSQL wire protocol expects a password.
+/// Nothing about the protocol changes — only where the bytes come from.
+/// </para>
+/// <para>
+/// Both the synchronous and asynchronous providers are implemented on purpose.
+/// Npgsql's documentation suggests throwing from the synchronous one, which is
+/// sound advice for connections you open yourself; Wolverine's durability
+/// subsystem owns connection lifecycles this project does not control, and a
+/// synchronous open inside it must not throw.
+/// </para>
+/// </remarks>
+public static class ApplicationDataSource
+{
+    /// <summary>
+    /// Configuration key that switches the connection onto Entra tokens.
+    /// Supplied in Azure as the <c>Azure__UseManagedIdentity</c> environment
+    /// variable (root <c>main.tf</c>, 14.43); defaults to <c>false</c> in
+    /// <c>appsettings.json</c> (14.46).
+    /// </summary>
+    public const string ManagedIdentityKey = "Azure:UseManagedIdentity";
+
+    /// <summary>
+    /// Name of the connection string this application reads. Aspire injects it
+    /// locally as <c>ConnectionStrings__currencytracker</c> (Phase 7.5);
+    /// Container Apps resolves it from Key Vault under the same name (14.43).
+    /// </summary>
+    public const string ConnectionStringName = "currencytracker";
+
+    /// <summary>
+    /// Token scope for the Azure Database for PostgreSQL resource. This exact
+    /// string is what the server validates against: a token for any other
+    /// resource is acquired successfully and then rejected at login, which is
+    /// why the scope lives in one named place rather than inline.
+    /// </summary>
+    private static readonly string[] Scopes =
+    [
+        "https://ossrdbms-aad.database.windows.net/.default",
+    ];
+
+    /// <summary>
+    /// Builds the data source for the current configuration.
+    /// </summary>
+    /// <param name="configuration">Host configuration.</param>
+    /// <param name="credential">
+    /// Credential used to acquire Entra tokens. Defaults to
+    /// <see cref="DefaultAzureCredential"/>, which resolves the container's
+    /// managed identity in Azure and a signed-in developer locally. Injected
+    /// only by tests.
+    /// </param>
+    /// <returns>A data source the caller owns and must dispose.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the <c>currencytracker</c> connection string is absent,
+    /// empty, or whitespace.
+    /// </exception>
+    public static NpgsqlDataSource Create(
+        IConfiguration configuration,
+        TokenCredential? credential = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // Whitespace, not just null. An empty string is a configuration VALUE
+        // in .NET, so an appsettings "placeholder" would satisfy a null check
+        // and silently disarm this guard — see docs/configuration.md (14.46).
+        var connectionString = configuration.GetConnectionString(ConnectionStringName);
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException(
+                $"The '{ConnectionStringName}' connection string is not configured. "
+                    + "Locally it is injected by the Aspire AppHost; in Azure it is a "
+                    + "Key Vault reference on the Container App (Phase 14.43)."
+            );
+        }
+
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionString);
+
+        if (!configuration.GetValue<bool>(ManagedIdentityKey))
+        {
+            return dataSourceBuilder.Build();
+        }
+
+        var tokenCredential = credential ?? new DefaultAzureCredential();
+
+        // Invoked on every PHYSICAL connection open, not on every command.
+        // Azure.Identity caches the token internally and hands back the cached
+        // value until it nears expiry, so this stays cheap without a second
+        // cache here — which is exactly what UsePeriodicPasswordProvider would
+        // add, with a hardcoded interval free to drift from the real lifetime.
+        dataSourceBuilder.UsePasswordProvider(
+            _ => AcquireToken(tokenCredential),
+            (_, cancellationToken) => AcquireTokenAsync(tokenCredential, cancellationToken)
+        );
+
+        return dataSourceBuilder.Build();
+    }
+
+    /// <summary>
+    /// Acquires an Entra access token for Azure Database for PostgreSQL.
+    /// </summary>
+    /// <param name="credential">Credential to acquire the token with.</param>
+    /// <returns>The raw JWT, used as the connection password.</returns>
+    internal static string AcquireToken(TokenCredential credential) =>
+        credential.GetToken(new TokenRequestContext(Scopes), CancellationToken.None).Token;
+
+    /// <summary>
+    /// Acquires an Entra access token for Azure Database for PostgreSQL.
+    /// </summary>
+    /// <param name="credential">Credential to acquire the token with.</param>
+    /// <param name="cancellationToken">Cancels the token request.</param>
+    /// <returns>The raw JWT, used as the connection password.</returns>
+    internal static async ValueTask<string> AcquireTokenAsync(
+        TokenCredential credential,
+        CancellationToken cancellationToken
+    )
+    {
+        var token = await credential.GetTokenAsync(
+            new TokenRequestContext(Scopes),
+            cancellationToken
+        );
+
+        return token.Token;
+    }
+}

--- a/src/CurrencyTracker.Worker/Program.cs
+++ b/src/CurrencyTracker.Worker/Program.cs
@@ -7,6 +7,7 @@ using CurrencyTracker.Application.Exceptions; // NotFoundException
 using CurrencyTracker.Application.Messaging;
 using CurrencyTracker.Domain.Exceptions; // DomainException
 using CurrencyTracker.Infrastructure;
+using CurrencyTracker.Infrastructure.Persistence; // ApplicationDataSource (14.44)
 using CurrencyTracker.ServiceDefaults;
 using CurrencyTracker.Worker.Configuration;
 using CurrencyTracker.Worker.Scheduling;
@@ -42,13 +43,13 @@ builder
 // dispatches resolve their ports through this.
 builder.AddInfrastructure();
 
-// The SAME connection string Phase 8 reads and Phase 7's AppHost injects.
-// Fail fast at boot if it's missing — the outbox cannot function without it.
-var currencyTrackerConnectionString =
-    builder.Configuration.GetConnectionString("currencytracker")
-    ?? throw new InvalidOperationException(
-        "Connection string 'currencytracker' is required for the Wolverine outbox/inbox."
-    );
+// 14.44 — the outbox authenticates like everything else. Wolverine takes an
+// NpgsqlDataSource overload, so the Entra token password provider is written
+// once (Infrastructure) and reused here. This is not a second connection pool:
+// PersistMessagesWithPostgresql(string) built its own data source internally
+// anyway — the only change is who configures it. The fail-fast on a missing
+// connection string now lives inside the factory, with a better message.
+var messagingDataSource = ApplicationDataSource.Create(builder.Configuration);
 
 builder
     .Services.AddOptions<WorkerOptions>()
@@ -101,7 +102,7 @@ builder.UseWolverine(opts =>
     opts.UseFluentValidation();
 
     // Durable transactional inbox/outbox in the SAME database, "wolverine" schema.
-    opts.PersistMessagesWithPostgresql(currencyTrackerConnectionString, "wolverine");
+    opts.PersistMessagesWithPostgresql(messagingDataSource, "wolverine");
 
     // Join Wolverine's messaging to the ApplicationDbContext transaction:
     // a handler's SaveChangesAsync and its outgoing/handled messages commit

--- a/src/CurrencyTracker.Worker/appsettings.json
+++ b/src/CurrencyTracker.Worker/appsettings.json
@@ -7,6 +7,9 @@
       }
     }
   },
+  "Azure": {
+    "UseManagedIdentity": false
+  },
   "Frankfurter": {
     "BaseUrl": "https://api.frankfurter.dev",
     "Timeout": "00:00:10",

--- a/tests/CurrencyTracker.Api.IntegrationTests/Endpoints/RatesLatestEndpointSmokeTests.cs
+++ b/tests/CurrencyTracker.Api.IntegrationTests/Endpoints/RatesLatestEndpointSmokeTests.cs
@@ -8,9 +8,15 @@ public sealed class RatesLatestEndpointSmokeTests
 {
     static RatesLatestEndpointSmokeTests()
     {
+        // The string must PARSE, even though nothing ever connects: 14.44 moved
+        // the Npgsql data source behind ApplicationDataSource.Create, which
+        // builds it during AddInfrastructure() instead of lazily on first use.
+        // This line previously ended in a literal "******" — a redaction that
+        // produced an unparseable connection string and went unnoticed for as
+        // long as UseNpgsql(string) deferred the parse.
         Environment.SetEnvironmentVariable(
             "ConnectionStrings__currencytracker",
-            "Host=localhost;Database=latest-rates-tests;Username=noop;" + "******"
+            "Host=localhost;Database=latest-rates-tests;Username=noop;Password=noop"
         );
         Environment.SetEnvironmentVariable("ConnectionStrings__cache", "localhost:6379");
     }

--- a/tests/CurrencyTracker.Api.IntegrationTests/Errors/ProblemDetailsContractTests.cs
+++ b/tests/CurrencyTracker.Api.IntegrationTests/Errors/ProblemDetailsContractTests.cs
@@ -110,9 +110,22 @@ public sealed class ProblemDetailsContractTests : IClassFixture<TestThrowsFactor
         // TestThrowsFactory's static constructor remains visible to
         // Program.cs because the process env-var is set once for the whole
         // test run.
+        //
+        // 14.47: booting as Production now loads appsettings.Production.json,
+        // which declares Authentication:Provider=EntraId — and the boot-time
+        // guard requires the authority to agree with it. The fixture's default
+        // authority is Keycloak-shaped, so a Production host has to be handed
+        // an Entra-shaped one. That is the guard working, not a test getting in
+        // the way: a host declaring Production while pointing at a realm is
+        // exactly the mismatch it exists to kill.
         using var productionFactory = _factory.WithWebHostBuilder(builder =>
-            builder.UseEnvironment("Production")
-        );
+        {
+            builder.UseEnvironment("Production");
+            builder.UseSetting(
+                "Authentication:Authority",
+                "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0"
+            );
+        });
         var client = productionFactory.CreateClient();
 
         // Act

--- a/tests/CurrencyTracker.Api.IntegrationTests/Security/AuthenticationProviderGuardTests.cs
+++ b/tests/CurrencyTracker.Api.IntegrationTests/Security/AuthenticationProviderGuardTests.cs
@@ -1,0 +1,79 @@
+using CurrencyTracker.Api.Security;
+
+namespace CurrencyTracker.Api.IntegrationTests.Security;
+
+/// <summary>
+/// Tests for the boot-time assertion that a declared identity provider agrees
+/// with the authority the host was actually given. The guard exists so a
+/// mismatched deployment dies at startup instead of booting green and rejecting
+/// every token at request time. Pure function, so no host is booted here — the
+/// tests live in this project only because the guard is <c>internal</c> and this
+/// is the assembly <c>InternalsVisibleTo</c> names.
+/// </summary>
+public sealed class AuthenticationProviderGuardTests
+{
+    private const string EntraAuthority =
+        "https://login.microsoftonline.com/04b94fa0-2449-42e3-b19d-3275d586556a/v2.0";
+
+    private const string KeycloakAuthority = "https://localhost:8080/realms/currency-tracker";
+
+    [Fact]
+    public void Validate_WithNoDeclaredProvider_AcceptsAnyAuthority()
+    {
+        // Arrange & Act
+        var act = () => AuthenticationProviderGuard.Validate(provider: null, KeycloakAuthority);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_WithEntraIdDeclaredAndAnEntraAuthority_Passes()
+    {
+        // Arrange & Act
+        var act = () => AuthenticationProviderGuard.Validate("EntraId", EntraAuthority);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData(KeycloakAuthority)]
+    [InlineData("http://login.microsoftonline.com/tenant/v2.0")] // not HTTPS
+    [InlineData("https://login.microsoftonline.com/tenant")] // no /v2.0
+    [InlineData("not-a-uri")]
+    public void Validate_WithEntraIdDeclaredAndAMismatchedAuthority_FailsFastNamingBoth(
+        string authority
+    )
+    {
+        // Arrange & Act
+        var act = () => AuthenticationProviderGuard.Validate("EntraId", authority);
+
+        // Assert
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*EntraId*")
+            .And.Message.Should()
+            .Contain(authority);
+    }
+
+    [Fact]
+    public void Validate_IsCaseInsensitiveAboutTheDeclaredProvider()
+    {
+        // Arrange & Act
+        var act = () => AuthenticationProviderGuard.Validate("entraid", EntraAuthority);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_WithAnUnknownDeclaredProvider_AssertsNothing()
+    {
+        // Arrange & Act
+        var act = () => AuthenticationProviderGuard.Validate("Keycloak", KeycloakAuthority);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+}

--- a/tests/CurrencyTracker.Infrastructure.UnitTests/Caching/CacheConnectionTests.cs
+++ b/tests/CurrencyTracker.Infrastructure.UnitTests/Caching/CacheConnectionTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using CurrencyTracker.Infrastructure.Caching;
+using FluentAssertions;
+using StackExchange.Redis;
+using Xunit;
+
+namespace CurrencyTracker.Infrastructure.UnitTests.Caching;
+
+/// <summary>
+/// Behavioural tests for <see cref="CacheConnection"/>'s option shaping. No
+/// network is touched: the value under test is the
+/// <see cref="ConfigurationOptions"/> the connection would be made with, which
+/// is where every Azure Managed Redis mistake actually lives — wrong port, TLS
+/// off, RESP2, or a password smuggled in.
+/// </summary>
+public sealed class CacheConnectionTests
+{
+    private const string LocalEndpoint = "localhost:6379";
+
+    private const string AzureEndpoint = "redis-ct-uat-9f3a.switzerlandnorth.redis.azure.net:10000";
+
+    [Fact]
+    public void BuildOptions_ForTheLocalCache_LeavesTlsOff()
+    {
+        // Arrange & Act
+        var options = CacheConnection.BuildOptions(LocalEndpoint, useManagedIdentity: false);
+
+        // Assert
+        options.Ssl.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildOptions_ForManagedRedis_RequiresTls()
+    {
+        // Arrange & Act
+        var options = CacheConnection.BuildOptions(AzureEndpoint, useManagedIdentity: true);
+
+        // Assert
+        options.Ssl.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildOptions_ForManagedRedis_SelectsResp3SoTheTokenRefreshCoversEveryConnection()
+    {
+        // Arrange & Act
+        var options = CacheConnection.BuildOptions(AzureEndpoint, useManagedIdentity: true);
+
+        // Assert
+        options.Protocol.Should().Be(RedisProtocol.Resp3);
+    }
+
+    [Fact]
+    public void BuildOptions_ForManagedRedis_KeepsThePortTheResourceReported()
+    {
+        // Arrange & Act
+        var options = CacheConnection.BuildOptions(AzureEndpoint, useManagedIdentity: true);
+
+        // Assert
+        options
+            .EndPoints.Should()
+            .ContainSingle()
+            .Which.Should()
+            .BeOfType<DnsEndPoint>()
+            .Which.Port.Should()
+            .Be(10000);
+    }
+
+    [Fact]
+    public void BuildOptions_ForManagedRedis_CarriesNoPassword()
+    {
+        // Arrange & Act
+        var options = CacheConnection.BuildOptions(AzureEndpoint, useManagedIdentity: true);
+
+        // Assert
+        options.Password.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildOptions_WithABlankEndpoint_FailsFast(string endpoint)
+    {
+        // Arrange & Act
+        var act = () => CacheConnection.BuildOptions(endpoint, useManagedIdentity: true);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/CurrencyTracker.Infrastructure.UnitTests/Persistence/ApplicationDataSourceTests.cs
+++ b/tests/CurrencyTracker.Infrastructure.UnitTests/Persistence/ApplicationDataSourceTests.cs
@@ -1,0 +1,169 @@
+using Azure.Core;
+using CurrencyTracker.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace CurrencyTracker.Infrastructure.UnitTests.Persistence;
+
+/// <summary>
+/// Behavioural tests for <see cref="ApplicationDataSource"/>: the fail-fast on
+/// missing configuration, the local (password) path, and the Entra path — in
+/// particular that the token requested is scoped to the Azure Database for
+/// PostgreSQL resource, which is the single most typo-prone value in Phase 14.E
+/// and the one whose mistake surfaces only as a login failure in Azure.
+/// </summary>
+public sealed class ApplicationDataSourceTests
+{
+    private const string LocalConnectionString =
+        "Host=localhost;Port=5432;Database=currencytracker;Username=postgres;Password=local-dev";
+
+    private const string AzureConnectionString =
+        "Host=psql-ct-uat.postgres.database.azure.com;Port=5432;"
+        + "Database=currencytracker;Username=ca-api-identity;SSL Mode=Require";
+
+    private const string PostgresScope = "https://ossrdbms-aad.database.windows.net/.default";
+
+    /// <summary>
+    /// Builds host configuration with the switch set and, optionally, the
+    /// connection string present.
+    /// </summary>
+    /// <param name="connectionString">
+    /// Connection string to publish, or null to model an absent one.
+    /// </param>
+    /// <param name="useManagedIdentity">Value of the Entra switch.</param>
+    /// <returns>Configuration to hand to the factory.</returns>
+    private static IConfiguration Configuration(string? connectionString, bool useManagedIdentity)
+    {
+        var values = new Dictionary<string, string?>
+        {
+            [ApplicationDataSource.ManagedIdentityKey] = useManagedIdentity ? "true" : "false",
+        };
+
+        if (connectionString is not null)
+        {
+            values[$"ConnectionStrings:{ApplicationDataSource.ConnectionStringName}"] =
+                connectionString;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    [Fact]
+    public void Create_WithoutAConnectionString_FailsFastWithAnActionableMessage()
+    {
+        // Arrange
+        var configuration = Configuration(connectionString: null, useManagedIdentity: false);
+
+        // Act
+        var act = () => ApplicationDataSource.Create(configuration);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>().WithMessage("*currencytracker*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithABlankConnectionString_FailsFastRatherThanBuildingANonsenseDataSource(
+        string connectionString
+    )
+    {
+        // Arrange
+        var configuration = Configuration(connectionString, useManagedIdentity: false);
+
+        // Act
+        var act = () => ApplicationDataSource.Create(configuration);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>().WithMessage("*currencytracker*");
+    }
+
+    [Fact]
+    public void Create_WithManagedIdentityOff_UsesTheSuppliedConnectionStringAsIs()
+    {
+        // Arrange
+        var configuration = Configuration(LocalConnectionString, useManagedIdentity: false);
+
+        // Act
+        using var dataSource = ApplicationDataSource.Create(configuration);
+
+        // Assert
+        dataSource.ConnectionString.Should().Contain("Host=localhost");
+    }
+
+    [Fact]
+    public void Create_WithManagedIdentityOn_RequestsNoTokenUntilAConnectionIsOpened()
+    {
+        // Arrange
+        var configuration = Configuration(AzureConnectionString, useManagedIdentity: true);
+        var credential = new RecordingTokenCredential();
+
+        // Act
+        using var dataSource = ApplicationDataSource.Create(configuration, credential);
+
+        // Assert
+        credential.RequestedScopes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AcquireToken_RequestsATokenScopedToAzureDatabaseForPostgreSql()
+    {
+        // Arrange
+        var credential = new RecordingTokenCredential();
+
+        // Act
+        var token = ApplicationDataSource.AcquireToken(credential);
+
+        // Assert
+        token.Should().Be(RecordingTokenCredential.StubToken);
+        credential.RequestedScopes.Should().ContainSingle().Which.Should().Equal(PostgresScope);
+    }
+
+    [Fact]
+    public async Task AcquireTokenAsync_RequestsATokenScopedToAzureDatabaseForPostgreSql()
+    {
+        // Arrange
+        var credential = new RecordingTokenCredential();
+
+        // Act
+        var token = await ApplicationDataSource.AcquireTokenAsync(
+            credential,
+            TestContext.Current.CancellationToken
+        );
+
+        // Assert
+        token.Should().Be(RecordingTokenCredential.StubToken);
+        credential.RequestedScopes.Should().ContainSingle().Which.Should().Equal(PostgresScope);
+    }
+
+    /// <summary>
+    /// In-memory <see cref="TokenCredential"/> that records the scopes it was
+    /// asked for. A fake rather than a substitute: the recorded state is what
+    /// the assertions read (AGENTS.md §Fakes live with tests).
+    /// </summary>
+    private sealed class RecordingTokenCredential : TokenCredential
+    {
+        /// <summary>Token value every request returns.</summary>
+        public const string StubToken = "stub-token";
+
+        /// <summary>Scopes captured from each token request, in order.</summary>
+        public List<string[]> RequestedScopes { get; } = [];
+
+        /// <inheritdoc />
+        public override AccessToken GetToken(
+            TokenRequestContext requestContext,
+            CancellationToken cancellationToken
+        )
+        {
+            RequestedScopes.Add(requestContext.Scopes);
+            return new AccessToken(StubToken, DateTimeOffset.UtcNow.AddHours(1));
+        }
+
+        /// <inheritdoc />
+        public override ValueTask<AccessToken> GetTokenAsync(
+            TokenRequestContext requestContext,
+            CancellationToken cancellationToken
+        ) => new(GetToken(requestContext, cancellationToken));
+    }
+}


### PR DESCRIPTION
Completes Phase 14.E — 14.43 through 14.47. 14.42 landed separately in #388.

## Why this is one PR

The repo's rule is one PR = one concept, and this is five. It was requested as
"complete the phase", and the five issues are stacked hard: 14.44's data source
is what 14.45's DI block sits next to, 14.46 hardens guards written in both, and
14.47's `strict: true` is only honest once 14.45's probes can pass. **Each issue
is one self-contained commit** — `git log --oneline origin/main..HEAD` reads as
the phase plan — so say the word and I'll split it into five stacked PRs.

## The commits

| Commit | What |
| --- | --- |
| `feat(14.43)` | Container App secret refs + plain env vars, both apps |
| `feat(14.44)` | `ApplicationDataSource`, Entra tokens for Postgres, ADR 0017 |
| `feat(14.45)` | `CacheConnection`, Entra tokens for Managed Redis, probes armed |
| `docs(14.46)` | `docs/configuration.md`, hardened config guards |
| `feat(14.47)` | `appsettings.Production.json`, provider guard, `strict: true` |

## Deviations from the issue text, argued

- **14.46 refuses empty-string placeholders.** In .NET an empty string is a
  configuration *value*: `GetConnectionString` returns `""`, not `null`, so a
  placeholder satisfies every `?? throw` in the codebase and disarms it. The
  four guards now test `IsNullOrWhiteSpace` instead, and the convention stands —
  a key the environment supplies does not appear in the file at all.
- **14.47 makes `Authentication:Provider` an assertion, not a branch.** An
  `if (provider == "EntraId")` in the auth pipeline would undo ADR 0010's
  config-only provider swap. `AuthenticationProviderGuard` checks that the
  declared provider agrees with the authority it was handed and dies at boot if
  not — no provider knowledge in the pipeline.
- **The precedence ladder is corrected.** "env vars > Key Vault > defaults" is
  one layer too many: a secret reference is resolved by the platform before the
  process starts and arrives as an ordinary env var. You cannot override Key
  Vault with an env var — same slot.

## New dependencies

`Azure.Identity` 1.21.0 (14.44) and `Microsoft.Azure.StackExchangeRedis` 3.3.1
(14.45), both verified as current on nuget.org at PR time, pinned in
`Directory.Packages.props`, referenced by `Infrastructure` only. ADR
`0017-passwordless-azure-data-plane-auth.md` covers both as one decision.
`StackExchange.Redis` stays transitive (resolved 2.10.1) rather than becoming a
second pin to hand-maintain.

`Application` gained nothing — no `ISecretProvider`, no `ITokenSource`.
`TokenCredential` is already the abstraction; a nine-line fake covers the tests.

## Evidence

```
dotnet csharpier check .              204 files, clean
dotnet format --verify-no-changes     clean
dotnet build -c Release               0 errors (TreatWarningsAsErrors)
terraform fmt -check -recursive       clean
terraform validate                    Success
```

Tests, local: **245 passing** across Domain (124), Application (66),
Architecture (7), Infrastructure.Unit (41), ServiceDefaults (5), Worker (2) —
plus the 8 new `AuthenticationProviderGuard` tests run under a filter.
**13 new tests** in this PR (7 `ApplicationDataSource`, 6 `CacheConnection`, 8
guard — the guard's `[Theory]` accounts for the arithmetic).

Docker Desktop was down on this machine, so the three container suites did not
run locally. **CI has now run everything green** — `ci-gate`, `format`,
`ci / test`, `codeql`, both integration legs, `coverage`, `gitleaks`,
`dependency-review`.

CI caught three things no local gate could, fixed in the final commit:

- **A latent unparseable connection string.** `RatesLatestEndpointSmokeTests`
  ended its string with a literal `"******"` — a redaction that had been
  harmless for exactly as long as `UseNpgsql(string)` deferred the parse. 14.44
  parses at boot, so it now throws. Fixed the string, not the laziness.
- **A `Production` test host now loads the `Production` profile**, so the
  declared-provider guard fired against the fixture's Keycloak-shaped authority.
  That is the guard working; the host was made coherent via `UseSetting`.
- **`gitleaks` reads the two tfvars identifiers as `generic-api-key`.** Allowed
  inline with the reason beside the value, not repo-wide. It scans every commit
  on the branch, so the allow had to ship *in* the 14.43 commit — the branch was
  rebuilt rather than stacking a fix on top.

### One gate is still red, and it isn't this phase's

`terraform-pr / terraform (uat)` fails on **30 tflint findings across all 12
modules** — `terraform_required_providers` and `terraform_required_version`, one
pair per module. None touch anything 14.E wrote; they date from 14.B and were
invisible because the workflow could not run until #391. `terraform-pr` is
advisory by design (`pipelines.md` §Gates), so this PR is `MERGEABLE`.

It needs its own decision, and I have not made it for you:

- **Add the two blocks to twelve modules** — what tflint wants, and duplication
  of a constraint the root `versions.tf` plus the committed lock file already
  own, in twelve places to keep in sync.
- **Disable those two rules in a commented `.tflint.hcl`** — consistent with the
  house rule that providers are configured once at the root and these modules are
  local-only, and it silences a linter, which is worth being uncomfortable about.

Say which and I'll do it as a separate PR.

## What is NOT verified, and cannot be from a PR

Everything Azure-side. Nothing in this branch has been applied or deployed:

- `terraform apply` against UAT — expect **4 changes**: probes on the Api,
  secrets + env vars on both apps.
- A `deploy-uat` run proving `/health/ready` returns 200 for the first time.
- The `strict: true` verdict on a real run.

The UAT apply also still needs the Key Vault data-plane grant question settled
(pipeline identity has it; your user account does not — see the earlier triage).
I have not applied anything; that is yours to run.

## Open items, deliberately not closed here

- **Smoke leg 3 stays dormant.** `SMOKE_TOKEN_RESOURCE` is set on the `uat`
  environment, but the API app registration still needs a role assignable to
  `gh-deploy-uat` plus admin consent. `AADSTS500011` is what its absence looks
  like. Recorded as **pending** in `pipelines.md` §Manual prerequisites; `strict`
  still gates the two health legs meanwhile.
- **PROD reuses UAT's app registration**, because only one exists. Flagged in
  `envs/prod/terraform.tfvars` as review-before-first-apply: a UAT-issued token
  would be accepted by PROD. Tolerable while PROD has never been applied; not a
  steady state.
- **PROD's first apply is two passes** (identity → grant → secret reference),
  and PROD's private vault still cannot be written from a hosted runner — the
  14.42 open item, untouched.
- **Migrations still do not run in Azure.** `/health/ready` passes anyway
  (`CanConnectAsync` never touches a table), so it does not block the phase, but
  it belongs to a deploy-step issue nobody has filed.

## Docs

`docs/configuration.md` (new), `docs/decisions/0017-…` (new), `docs/caching.md`
§In Azure, `docs/auth.md` §In Azure, `docs/ci-cd/pipelines.md` (§Seams retitled
and flipped, §Smoke, §Manual prerequisites, the graph), `README.md` docs list.

`AGENTS.md` is **not** touched, per its own §Don't — but it now carries one
inaccuracy this PR contradicts: its gotcha says a connection string in
`appsettings.json` would *shadow* the Aspire-injected one. Env vars are added
after the JSON providers, so an env var wins. The gotcha's conclusion still
holds for a sharper reason, which `docs/configuration.md` states. Your call
whether to correct the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
