### PR TITLE
fix(14.30): add the missing .trivyignore the scan gate requires

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,20 @@
+# .trivyignore — the reviewed CVE allowlist for the container images scanned by
+# _reusable-trivy-scan.yml, between docker-build and acr-push in main-ci.
+#
+# EMPTY IS THE CORRECT DEFAULT, but the file must exist: trivy-action fails the
+# job outright with "cannot find ignorefile '.trivyignore'" when the path in
+# `trivyignores:` is missing. That error had failed every main-ci run since the
+# trunk pipeline landed, which is why no image pair has ever reached ACR.
+#
+# The gate is severity HIGH,CRITICAL with ignore-unfixed:true. So anything
+# listed below is a HIGH or CRITICAL *with a fix available* that a human chose
+# not to take. That is a deliberate acceptance of known-fixable risk — write it
+# down like one:
+#
+#   # CVE-2025-XXXXX — <package>: <why this image is not exposed to it>.
+#   # Accepted by <who>, revisit <YYYY-MM-DD>.
+#   CVE-2025-XXXXX
+#
+# Adding a line here to make a red build green, without that reasoning, is the
+# thing the file exists to prevent. Prefer bumping the base image or the
+# offending package; an entry here is the last resort, not the first.


### PR DESCRIPTION
## The bug

`_reusable-trivy-scan.yml:40` has always passed `trivyignores: .trivyignore`, but **that file has never existed in the repo** — `git ls-files | grep trivy` returns only the workflow itself. `trivy-action` treats a missing ignorefile as fatal rather than skipping it:

```
ERROR: cannot find ignorefile '.trivyignore'.
##[error]Process completed with exit code 1
```

So `trivy-api` and `trivy-worker` failed **before scanning a single layer**, `push-api` / `push-worker` were skipped by their `needs:` edge, and no image pair has ever reached ACR. All 8 `main-ci` runs on `main` failed this way.

That is also the answer to "why can't I dispatch `deploy-uat`": its `gate` job verifies the manifest exists before Terraform touches anything, and there has never been anything to find.

## The fix

Add the file the workflow already expects. It has **no entries**, which is the correct default — the gate's strictness is unchanged. This restores a scan that was never running; it does not loosen one.

The header documents what an entry costs, because the failure mode of an allowlist is someone appending a line to turn a build green. Under `severity: HIGH,CRITICAL` + `ignore-unfixed: true`, any future entry is a **fixable** HIGH/CRITICAL that a human chose not to fix, so each one needs the CVE id, why the image isn't exposed, who accepted it, and when it gets re-checked.

## Verification

Building both images locally and running the gate's exact settings against the exported tarballs — the same way the workflow scans them, `--input` on the tar rather than a registry ref:

| Image | Targets | Findings | Exit |
| --- | --- | --- | --- |
| `api` | ubuntu 24.04 + 3 dotnet-core | **0** | 0 |
| `worker` | ubuntu 24.04 + 3 dotnet-core | **0** | 0 |

`severity HIGH,CRITICAL`, `--ignore-unfixed`, `--exit-code 1`, `--ignorefile .trivyignore`.

Both images are clean today, so **no CVE needs accepting** and the empty file is sufficient to unblock the pipeline. Worth noting the chiseled base is doing real work here: 8 OS packages total in the final image.

Also confirmed `.trivyignore` isn't caught by `.gitignore` — relevant given the blanket `*.json` rule that lived there until 15.1.

## Ordering

Independent of #395 and #396 (different files, different workflows) — merge in any order. Once this lands, the next push to `main` should produce the first image pair in ACR, and `deploy-uat` becomes dispatchable with that commit's SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
