### PR TITLE
fix(14.45): set explicit probe timings on the Api container app

### DIFF
--- a/infra/terraform/modules/container-app-api/main.tf
+++ b/infra/terraform/modules/container-app-api/main.tf
@@ -97,6 +97,19 @@ resource "azurerm_container_app" "api" {
 
       # Probes target the Phase 13.B health contract; gated until the real
       # image (which serves those paths) is deployed by 14.D.
+      #
+      # EVERY TIMING IS EXPLICIT ON PURPOSE. Omitting them does not mean
+      # "sensible platform defaults" — azurerm defaults `timeout` to 1 SECOND
+      # and readiness `success_count_threshold` to 3. Under those, the first
+      # real deploy never converged: /health/ready opens a Postgres connection
+      # and pings Redis, both of which acquire an Entra token over managed
+      # identity first, so the probe timed out 184 consecutive times, the
+      # replica never went Ready, and runningState sat at "Activating" until
+      # the deploy's health gate gave up. The container was healthy the whole
+      # time — it logged "Now listening on: http://[::]:8080" in 8 seconds.
+      #
+      # A defaulted probe is a probe nobody chose. Change these only against a
+      # measured p99 of the endpoint they poll.
       dynamic "liveness_probe" {
         for_each = var.health_probes_enabled ? [1] : []
 
@@ -104,6 +117,14 @@ resource "azurerm_container_app" "api" {
           transport = "HTTP"
           port      = var.target_port
           path      = "/health/live"
+
+          # /health/live is the `self` check: no dependencies, no I/O. It stays
+          # tight because a slow answer here really is a sick process — but not
+          # 1s tight, which would restart the container over a GC pause.
+          initial_delay           = 10
+          interval_seconds        = 10
+          timeout                 = 5
+          failure_count_threshold = 3
         }
       }
 
@@ -114,6 +135,20 @@ resource "azurerm_container_app" "api" {
           transport = "HTTP"
           port      = var.target_port
           path      = "/health/ready"
+
+          # Readiness is allowed to be slow: it does real dependency I/O, and
+          # the cold path (token acquisition + TLS + EF model build) is the
+          # slowest request this app will ever serve.
+          #
+          # success_count_threshold = 1 is the important one. The default of 3
+          # forces three consecutive passes 10s apart, adding 20s of dead time
+          # to every deploy for no signal — readiness is re-evaluated forever,
+          # so a fluke pass self-corrects on the next interval.
+          initial_delay           = 10
+          interval_seconds        = 15
+          timeout                 = 10
+          failure_count_threshold = 6
+          success_count_threshold = 1
         }
       }
     }


### PR DESCRIPTION
Fixes the failed health gate in [job 90075307308](https://github.com/mpcs2013/currency-tracker/actions/runs/30295231688).

## What actually happened

The Api revision `ca-ct-uat-api--0000004` sat at `runningState: Activating` for the full 5-minute poll. The Worker converged in 23 seconds.

**The container was never unhealthy.** It logged `Now listening on: http://[::]:8080` and `Application started` 8 seconds in, and 300 lines of console log contain no error, no Npgsql failure, no Redis failure. The system log says what actually happened — 184 times:

```
Probe of Readiness failed with timeout in 1 seconds.
```

## Root cause

The probe blocks set only `transport`, `port`, `path`. Every timing fell to the azurerm default, and the defaults are not neutral:

```json
{ "type": "Readiness", "timeoutSeconds": 1, "successThreshold": 3,
  "initialDelaySeconds": 0, "periodSeconds": 10, "failureThreshold": 3 }
```

`/health/ready` runs `PostgresHealthCheck` (EF `CanConnectAsync`, which opens a real connection) and `RedisHealthCheck`. Under managed identity both acquire an Entra token before their first byte crosses the wire, on top of first-request EF model building. **One second was never achievable.** The probe timed out on every attempt, the replica never went Ready, and the strict gate correctly refused to call that a deploy.

Worth stating precisely: it **timed out** rather than returning 503. The console log shows `RequestPath: "/health/ready"` being handled, so the request arrived and started — it just could not finish in time. This is a timing defect, not a connectivity one.

The Worker is unaffected: no ingress, no probes.

## The change

| | Was (defaulted) | Now |
| --- | --- | --- |
| liveness `timeout` | 1s | 5s |
| liveness `initial_delay` | 1s | 10s |
| readiness `timeout` | **1s** | 10s |
| readiness `success_count_threshold` | **3** | 1 |
| readiness `failure_count_threshold` | 3 | 6 |
| readiness `interval_seconds` | 10s | 15s |
| readiness `initial_delay` | 0s | 10s |

`success_count_threshold = 1` is the quiet win: the default of 3 forces three consecutive passes 10s apart, adding 20 seconds of dead time to every deploy for no signal — readiness is re-evaluated forever, so a fluke pass self-corrects on the next interval.

Liveness stays comparatively tight because `/health/live` is the dependency-free `self` check, where a slow answer really does mean a sick process — but 5s rather than 1s, so a GC pause cannot restart the container.

The comment in the file records why these are explicit, so nobody "simplifies" them back to defaults.

## Verification

`terraform fmt -check -recursive`, `terraform validate` and `tflint --recursive` all exit 0. Attribute names were confirmed against the provider's own schema (`terraform providers schema -json`) rather than assumed — `readiness_probe` does accept `initial_delay`, which is easy to get wrong since it is not in every azurerm version's docs.

This changes the app's infrastructure shape, so it needs a `deploy-uat` dispatch with `apply-terraform=true` to take effect.

## What this does not prove

I could not measure `/health/ready`'s true latency: ingress returns 404 while no replica is Ready, and the chiseled image has no shell for `az containerapp exec`. If the endpoint is genuinely broken rather than merely slow, this change will not make it pass — but it will make it **fail fast with a 503** instead of timing out, which is a diagnosable failure with app logs behind it.

## Unrelated thing worth knowing

The console log shows `Failed to determine the https port for redirect` from `HttpsRedirectionMiddleware` on `/health/ready`. Benign today — with no HTTPS port configured the middleware logs and passes the request through. But if `ASPNETCORE_HTTPS_PORTS` is ever set, that middleware would start 307-redirecting the probe and readiness would break in a way that looks nothing like its cause. Container Apps terminates TLS at ingress and this container only ever serves HTTP on 8080, so `UseHttpsRedirection()` arguably does not belong in it at all. Left alone deliberately — separate concern, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
