### PR TITLE
fix(14.17): give UAT Postgres a firewall, without which nothing can connect

### DIFF
--- a/infra/terraform/envs/prod/terraform.tfvars
+++ b/infra/terraform/envs/prod/terraform.tfvars
@@ -16,6 +16,12 @@ postgres_zone_redundant = true
 # PROD has no public network access — private endpoints only (enforced in 14.G).
 enable_public_network_access = false
 
+# False, and it must stay false: PROD's Postgres is VNet-injected through the
+# delegated subnet, so there is no public endpoint for a firewall rule to guard.
+# The module skips both firewall resources in the private posture; this is the
+# explicit statement of intent rather than a default nobody chose.
+postgres_allow_azure_services = false
+
 # Environment VNet. Non-overlapping with UAT (10.20.0.0/16).
 vnet_address_space = ["10.30.0.0/16"]
 

--- a/infra/terraform/envs/uat/terraform.tfvars
+++ b/infra/terraform/envs/uat/terraform.tfvars
@@ -16,6 +16,14 @@ postgres_zone_redundant = false
 # UAT is reachable publicly but firewalled to known ranges (tightened in 14.G).
 enable_public_network_access = true
 
+# The firewall those "known ranges" refer to. It did not exist until now, and a
+# public Flexible Server with no rules denies everything — the Api's readiness
+# probe hung on a dropped connect to 5432 and UAT never converged. Azure-internal
+# is the only grain available: the Container Apps environment is external and
+# egresses from a rotating pool of ~160 public IPs, so there is no address to
+# pin. Password auth is off, so this opens a port, not an account.
+postgres_allow_azure_services = true
+
 # Environment VNet. Non-overlapping with PROD (10.30.0.0/16) so the two could
 # be peered later without renumbering. Subnets are derived in modules/network.
 vnet_address_space = ["10.20.0.0/16"]

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -95,6 +95,8 @@ module "postgres" {
   sku_name                     = var.postgres_sku_name
   zone_redundant               = var.postgres_zone_redundant
   enable_public_network_access = var.enable_public_network_access
+  allow_azure_services         = var.postgres_allow_azure_services
+  allowed_ip_ranges            = var.postgres_allowed_ip_ranges
   delegated_subnet_id          = module.network.postgres_subnet_id
   vnet_id                      = module.network.vnet_id
   tags                         = local.common_tags

--- a/infra/terraform/modules/postgres/main.tf
+++ b/infra/terraform/modules/postgres/main.tf
@@ -121,3 +121,37 @@ resource "azurerm_postgresql_flexible_server_database" "app" {
     prevent_destroy = true
   }
 }
+
+# Firewall — public posture only. A Flexible Server with publicNetworkAccess
+# Enabled and an EMPTY rule list is not "open", it is CLOSED: Azure denies every
+# connection. That is not a hypothetical. It is what the server shipped as, and
+# it stalled the first two UAT deploys — the Api's readiness probe hung on a TCP
+# connect to 5432 that was being dropped, timed out, and the revision never left
+# "Activating". Nothing logged, because nothing ever failed; it just never
+# answered.
+#
+# The private posture has no firewall surface at all (traffic arrives through
+# the delegated subnet), so both resources are absent there rather than empty.
+
+resource "azurerm_postgresql_flexible_server_firewall_rule" "azure_services" {
+  #checkov:skip=CKV2_AZURE_26:Checkov reads the start address and sees 0.0.0.0, which in a firewall rule normally means the internet. Here it is Azure's sentinel for "Azure-internal resources only" — the range is 0.0.0.0-0.0.0.0, not 0.0.0.0-255.255.255.255, and the internet cannot reach the server through it. Stated plainly, the residual exposure is real but bounded: resources in OTHER Azure tenants can also open a TCP connection. They get nothing — password_auth_enabled is false, so a connection without an Entra token for a registered administrator is refused at the protocol level. Narrowing this further needs the apps off the public endpoint entirely (VNet integration, as PROD already does), not a tighter CIDR.
+  count = !local.private && var.allow_azure_services ? 1 : 0
+
+  # 0.0.0.0-0.0.0.0 is not "all addresses" — it is Azure's documented sentinel
+  # for "any Azure-internal resource". The apps are the reason it is here: an
+  # external Container Apps environment egresses from a large, rotating pool of
+  # public IPs, so there is no address to pin.
+  name             = "AllowAzureServices"
+  server_id        = azurerm_postgresql_flexible_server.this.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+
+resource "azurerm_postgresql_flexible_server_firewall_rule" "allowed" {
+  for_each = local.private ? {} : var.allowed_ip_ranges
+
+  name             = each.key
+  server_id        = azurerm_postgresql_flexible_server.this.id
+  start_ip_address = each.value.start_ip
+  end_ip_address   = each.value.end_ip
+}

--- a/infra/terraform/modules/postgres/variables.tf
+++ b/infra/terraform/modules/postgres/variables.tf
@@ -28,6 +28,21 @@ variable "enable_public_network_access" {
   type        = bool
 }
 
+variable "allow_azure_services" {
+  description = "Create the 0.0.0.0 firewall rule that admits traffic from Azure resources. Required in the public posture: a Flexible Server with publicNetworkAccess=Enabled and NO firewall rules denies EVERY connection, which is what stalled the first UAT deploy — the Api's readiness probe hung on a dropped TCP connect to 5432. Container Apps cannot be allow-listed by address (an external environment's outbound pool is ~160 IPs and is not stable), so this is the only workable grain. It is a network rule, not an authentication one: password auth is off, so reaching the port still gets you nothing without an Entra token for a registered administrator. Ignored when enable_public_network_access = false — the private posture has no firewall to configure."
+  type        = bool
+  default     = false
+}
+
+variable "allowed_ip_ranges" {
+  description = "Named IPv4 ranges admitted in addition to Azure services, e.g. an office range for psql access. Keyed by rule name so a range can be removed without renumbering the rest. Ignored in the private posture."
+  type = map(object({
+    start_ip = string
+    end_ip   = string
+  }))
+  default = {}
+}
+
 variable "delegated_subnet_id" {
   description = "Subnet delegated to Microsoft.DBforPostgreSQL/flexibleServers (from modules/network). Consumed only when enable_public_network_access = false."
   type        = string

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -37,6 +37,20 @@ variable "enable_public_network_access" {
   type        = bool
 }
 
+variable "postgres_allow_azure_services" {
+  description = "Admit Azure-internal traffic to Postgres (the 0.0.0.0 sentinel rule). Must be true wherever the apps reach the server over its public endpoint — a public server with no firewall rules refuses everything, silently. Pairs with enable_public_network_access: true in UAT, false in PROD where the delegated subnet carries the traffic instead."
+  type        = bool
+}
+
+variable "postgres_allowed_ip_ranges" {
+  description = "Named IPv4 ranges admitted to Postgres in addition to Azure services (e.g. an office range for psql). Empty by default: every range here is a hole in the perimeter that outlives whoever opened it."
+  type = map(object({
+    start_ip = string
+    end_ip   = string
+  }))
+  default = {}
+}
+
 variable "vnet_address_space" {
   description = "Address space for the environment VNet. UAT and PROD must not overlap (peering-safe)."
   type        = list(string)


### PR DESCRIPTION
Fixes the health-gate failure in [job 90088198535](https://github.com/mpcs2013/currency-tracker/actions/runs/30299094300). **This is the actual root cause; #400 was a real but insufficient fix.**

## The finding

```
az rest ... /flexibleServers/psql-ct-uat-uivw/firewallRules  →  []
```

`psql-ct-uat-uivw` has `publicNetworkAccess: Enabled` and **zero firewall rules**. For Flexible Server that combination is not "open", it is **closed** — an empty rule list denies every connection.

So `PostgresHealthCheck.CanConnectAsync` sat waiting on Npgsql's ~15s connect timeout, the readiness probe gave up first, the replica never left `Activating`, and the strict gate failed. **Nothing was logged because nothing ever failed** — it simply never answered.

## Why #400 appeared to do nothing

It did work. The deployed probe now reads `timeoutSeconds: 10, successThreshold: 1, failureThreshold: 6`. But 10s is still below Npgsql's ~15s connect timeout, so a dropped connect still presents as a probe timeout.

Two defects were stacked and the first masked the second. The 1-second probe made *any* dependency work impossible; fixing it revealed that the dependency was unreachable. Both changes are needed — and the second run is what proved it, because a merely-slow endpoint would have passed at 10s.

Credit where due: **@mpcs2013's observation that the Api waits on Keycloak locally is what redirected this from "tune the probe" to "check the dependency".** That was the right instinct.

## The fix

The UAT envelope always said *"reachable publicly but firewalled to known ranges"*. The firewall was the part nobody built. This adds it:

- `allow_azure_services` → the `0.0.0.0`–`0.0.0.0` rule
- `allowed_ip_ranges` → a named map for office/CI ranges, empty by default
- Both absent in the private posture — PROD has no public endpoint to guard

**Azure-internal is the only grain available.** The Container Apps environment is external (`internal: false`) and egresses from a rotating pool of ~160 public addresses — `properties.outboundIpAddresses` returns the whole list. There is no address to pin.

## The security position, stated plainly

The `0.0.0.0`–`0.0.0.0` rule is Azure's sentinel for "Azure-internal resources", not `0.0.0.0/0`. The internet cannot reach the server through it.

But it is broader than ideal: **resources in other Azure tenants can complete a TCP handshake.** They get nothing — `password_auth_enabled = false`, so a connection without an Entra token for a registered administrator is refused at the protocol level. This opens a port, not an account.

Checkov flags it as `CKV2_AZURE_26` and cannot distinguish the sentinel from an internet rule. Rather than silence it, the exception records the residual exposure and what would actually close it: taking the apps off the public endpoint entirely via VNet integration, as PROD already does. That is a deliberate follow-up, not something to smuggle into a hotfix.

## Verification

`fmt`, `validate`, `tflint` clean. Checkov **0 failed** against both envelopes (23 skipped — one more than before, the new `CKV2_AZURE_26`).

Needs `deploy-uat` with `apply-terraform=true`.

## Honest caveat

I cannot prove this is the *last* blocker. It is definitively *a* blocker — the empty rule list is not a judgement call. But `/health/ready` also checks Redis, and smoke leg 3 still needs the `user` app role that remains pending. If readiness goes green and the run then dies at smoke, that is the app role, not a regression here.

What will be different either way: failures from this point produce **logs**. A refused connection throws and gets recorded; a dropped one never did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
