### PR TITLE
docs(14.47): correct the smoke-leg-3 prerequisite — it was never the app role

### DIFF
--- a/docs/azure/bootstrap.md
+++ b/docs/azure/bootstrap.md
@@ -29,6 +29,53 @@ misleading `SubscriptionNotFound`: `Microsoft.Storage`, `Microsoft.KeyVault`,
 | gh-deploy-uat   | `c21f81b0-c5fe-4854-bc53-e88e913f59d3`  | `b011b5ac-1da4-4986-920e-6c5f29271e33`	| created           |
 | gh-deploy-prod  | `4fbd780a-9e9f-41c9-bed2-98d3509d0aa1`  | `b99eedea-11b9-4817-8141-1e1f7625e055`	| created           |
 
+### MSApi — the API app registration the Api validates tokens against
+
+Not a deploy identity. This is the resource `Authentication__Audience` names and
+the audience `SMOKE_TOKEN_RESOURCE` requests a token for.
+
+| Field | Value |
+| ----- | ----- |
+| App (client) ID | `e50b769e-1b9e-487d-baf5-7108f98935f2` |
+| Object ID       | `6424a67b-d03b-4174-a7a7-f86e5b754bd3` |
+| Service principal object ID | `6424a67b-d03b-4174-a7a7-f86e5b754bd3` |
+| `appRoleAssignmentRequired` | `false` |
+
+**It shipped bare and must be configured before any authenticated call
+succeeds** — discovered 2026-07-27 while trying to call
+`/api/v1/rates/latest` by hand. As created it had no `identifierUris`, no
+`oauth2PermissionScopes`, no `preAuthorizedApplications`, no `appRoles`, and
+`requestedAccessTokenVersion` unset:
+
+| Setting | Required value | Why |
+| ------- | -------------- | --- |
+| `identifierUris` | `["api://e50b769e-1b9e-487d-baf5-7108f98935f2"]` | Something for a client to request a token *for*. |
+| `api.requestedAccessTokenVersion` | `2` | **The one that is not optional.** Unset means v1, whose issuer is `https://sts.windows.net/<tid>/`. `Program.cs` sets `ValidIssuer = authAuthority`, an exact match against `https://login.microsoftonline.com/<tid>/v2.0`, so a v1 token 401s on issuer before audience is even examined. |
+| `api.oauth2PermissionScopes` | one scope, `access_as_user` | Without a scope there is nothing to consent to, and every token request fails `AADSTS65001`. |
+| `api.preAuthorizedApplications` | Azure CLI `04b07795-8ddb-461a-bbee-02f9e1bf7b46` | Lets `az account get-access-token` mint a token non-interactively, for smoke and for humans. |
+
+A `PATCH` to `api` replaces the whole object, so set the scope and the
+pre-authorized app in that order and reuse the same scope `id` in both calls —
+the second call otherwise silently erases the first.
+
+Fetching a token afterwards:
+
+```powershell
+az account get-access-token `
+  --scope "api://e50b769e-1b9e-487d-baf5-7108f98935f2/access_as_user" `
+  --query accessToken -o tsv
+```
+
+`--scope` is the v2 form. `--resource` requests a v1 token and will fail issuer
+validation no matter what else is correct.
+
+**No app roles are defined, and the read paths do not need any.**
+`Program.cs`'s `MapWolverineEndpoints(opts => opts.RequireAuthorizeOnAll())`
+applies the default policy — authenticated user, no role. Only
+`AdminIngestEndpoint` carries `[Authorize(Policy = "admin")]`, so the `user` /
+`admin` roles that [`docs/auth.md`](../auth.md) recommends are needed for the
+admin endpoint and nothing else. They are **not** a prerequisite for smoke.
+
 ## Federated credentials (14.2) — issuer `https://token.actions.githubusercontent.com`, audience `api://AzureADTokenExchange`
 | App             | Credential name  | Subject                                                     |
 | --------------- | ---------------- | ----------------------------------------------------------- |

--- a/docs/ci-cd/pipelines.md
+++ b/docs/ci-cd/pipelines.md
@@ -290,7 +290,18 @@ them can succeed. Record values in [`docs/azure/bootstrap.md`](../azure/bootstra
 | `SLACK_WEBHOOK_URL`                               | repo-level **secret**    | `notify` (both leaves)   | optional |
 | `NOTIFICATIONS_ENABLED`                           | repo-level **variable**  | `notify` kill-switch     | optional |
 | `SMOKE_TOKEN_RESOURCE`                            | `uat` env var            | smoke leg 3              | 14.47 ✅ |
-| `user` app role on the API app registration, assigned to `gh-deploy-uat` + admin consent | Entra ID | smoke leg 3 | **pending** |
+| `MSApi` configured as an API: `api://` identifier URI, `requestedAccessTokenVersion: 2`, an `access_as_user` scope, Azure CLI pre-authorised | Entra ID | smoke leg 3 | **pending** |
+
+**Corrected 2026-07-27.** This row used to read *"`user` app role on the API app
+registration, assigned to `gh-deploy-uat` + admin consent"*. That was wrong in
+both halves and sent two debugging sessions after a phantom:
+`MSApi` defines **no app roles at all**, so there was nothing to assign — and
+`/api/v1/rates/latest`, the endpoint smoke leg 3 calls, needs no role.
+`MapWolverineEndpoints(opts => opts.RequireAuthorizeOnAll())` applies the default
+authenticated-user policy; only `AdminIngestEndpoint` requires `admin`. The real
+prerequisite is that the registration was never configured as an API — see
+[`docs/azure/bootstrap.md`](../azure/bootstrap.md) §MSApi for the four settings
+and why `requestedAccessTokenVersion: 2` is the load-bearing one.
 
 The promotion pair:
 

--- a/docs/ci-cd/uat-deploy-runbook.md
+++ b/docs/ci-cd/uat-deploy-runbook.md
@@ -19,43 +19,67 @@ does not do](#what-this-pipeline-deliberately-does-not-do).
 
 Four conditions decide whether a dispatch can succeed.
 
-### Blocking: the `user` app role is not assigned to `gh-deploy-uat`
+### Blocking: `MSApi` is not configured as an API
 
 Smoke leg 3 requests a token for `SMOKE_TOKEN_RESOURCE` and calls
 `/api/v1/rates/latest`. That variable **is** set on the `uat` environment, so the
-leg runs. Without the app role the token carries no role, the Api refuses the
-request, the payload assertion fails — and because `deploy-uat.yml` sets
-`strict: true`, a failed smoke leg is a **failed deploy**, not a warning.
+leg runs — and because `deploy-uat.yml` sets `strict: true`, a failed smoke leg
+is a **failed deploy**, not a warning. It fails at the *last* step, after
+Terraform has applied and both apps have been updated.
 
-It fails at the *last* step, after Terraform has applied and both apps have been
-updated. Resolve it before the first dispatch.
+No token can be issued for this API today. Verified by trying it:
 
-Listed as **pending** in [`pipelines.md`](pipelines.md) §Manual prerequisites.
-
-```bash
-# 1. The API app registration's appRole id for "user"
-az ad app show --id e50b769e-1b9e-487d-baf5-7108f98935f2 \
-  --query "appRoles[?value=='user'].{value:value,id:id}" -o table
-
-# 2. Object ids: the API's service principal, and gh-deploy-uat's
-az ad sp list --filter "appId eq 'e50b769e-1b9e-487d-baf5-7108f98935f2'" --query "[0].id" -o tsv
-az ad sp list --display-name gh-deploy-uat --query "[0].id" -o tsv
-
-# 3. What gh-deploy-uat already holds (empty output = the role is missing)
-az rest --method GET \
-  --url "https://graph.microsoft.com/v1.0/servicePrincipals/<gh-deploy-uat-sp-id>/appRoleAssignments"
-
-# 4. Grant it. Needs an admin; this is the mutating step.
-az rest --method POST \
-  --url "https://graph.microsoft.com/v1.0/servicePrincipals/<gh-deploy-uat-sp-id>/appRoleAssignments" \
-  --headers "Content-Type=application/json" \
-  --body '{"principalId":"<gh-deploy-uat-sp-id>","resourceId":"<api-sp-object-id>","appRoleId":"<user-role-id>"}'
+```
+az account get-access-token --resource e50b769e-1b9e-487d-baf5-7108f98935f2
+→ AADSTS65001: The user or administrator has not consented to use the
+  application with ID '04b07795-...' named 'Microsoft Azure CLI'.
 ```
 
-These are written from the identity values recorded in
-[`../azure/bootstrap.md`](../azure/bootstrap.md), not from a successful run. An
-app-role grant is a tenant change with an admin-consent step — read each command
-before running it.
+App registration `MSApi` was created bare: no `identifierUris`, no
+`oauth2PermissionScopes`, no `preAuthorizedApplications`, and
+`requestedAccessTokenVersion` unset (which means **v1**). Two independent
+blockers — nothing to request a token *for*, and the wrong token version even if
+there were. `Program.cs` sets `ValidIssuer = authAuthority`, an exact match
+against `…/v2.0`, so a v1 token's `sts.windows.net` issuer 401s before the
+audience is even examined.
+
+The four settings, and the ordering trap in applying them, are in
+[`../azure/bootstrap.md`](../azure/bootstrap.md) §MSApi. Object id
+`6424a67b-d03b-4174-a7a7-f86e5b754bd3`.
+
+Once applied, this is the call — `--scope` (v2), never `--resource` (v1):
+
+```powershell
+$token = az account get-access-token `
+  --scope "api://e50b769e-1b9e-487d-baf5-7108f98935f2/access_as_user" `
+  --query accessToken -o tsv
+
+$fqdn = az containerapp show -n ca-ct-uat-api -g rg-currencytracker-uat `
+  --query properties.configuration.ingress.fqdn -o tsv
+
+Invoke-RestMethod -Uri "https://$fqdn/api/v1/rates/latest?base=USD&target=EUR" `
+  -Headers @{ Authorization = "Bearer $token" }
+```
+
+On a 401, decode the token before suspecting the Api. Only two claims decide it:
+`iss` must end `/v2.0`, and `aud` must equal the bare GUID that
+`Authentication__Audience` carries.
+
+```powershell
+$p = $token.Split('.')[1].Replace('-','+').Replace('_','/')
+$p = $p.PadRight($p.Length + (4 - $p.Length % 4) % 4, '=')
+[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($p)) | ConvertFrom-Json |
+  Select-Object iss, aud, scp, roles, preferred_username
+```
+
+> **This section previously named the wrong cause.** It said smoke leg 3 was
+> blocked by a pending `user` app role assigned to `gh-deploy-uat`, inherited
+> from [`pipelines.md`](pipelines.md) §Manual prerequisites. `MSApi` defines no
+> app roles at all, so there was nothing to assign — and this endpoint needs no
+> role: `RequireAuthorizeOnAll()` applies the default authenticated-user policy,
+> and only `AdminIngestEndpoint` requires `admin`. The `user` / `admin` roles
+> [`../auth.md`](../auth.md) recommends are still worth having for the admin
+> endpoint; they were simply never what blocked this.
 
 ### The other three
 
@@ -249,9 +273,12 @@ the run cleanly and leaves the environment untouched.
 | `azure/login` fails (AADSTS700213 etc.) | Federated credential subject mismatch | Compare against `repo:mpcs2013/currency-tracker:environment:uat` on `gh-deploy-uat` |
 | Terraform apply fails on a lock | A previous run died mid-apply | Inspect before forcing — the lock lives in the `stcurrencytrackertfstate` backend |
 | Revision never reaches a healthy state | The app is fail-fasting at boot on missing config | `az containerapp logs show -n ca-ct-uat-api -g rg-currencytracker-uat --type console --tail 200` |
+| Stuck `Activating`, `h: "None"`, and **console logs show a clean start with no errors** | A readiness dependency is dropping connections, not refusing them. Nothing logs because nothing fails — it never answers. Check the **system** log for `Probe of Readiness failed with timeout` | `az containerapp logs show -n ca-ct-uat-api -g rg-currencytracker-uat --type system --tail 30` |
+| …and the dependency is Postgres | A public Flexible Server with an **empty** firewall rule list denies everything. Cost two deploys on 2026-07-27 | `az rest --method GET --url "https://management.azure.com/subscriptions/<sub>/resourceGroups/rg-currencytracker-uat/providers/Microsoft.DBforPostgreSQL/flexibleServers/<server>/firewallRules?api-version=2024-08-01"` |
 | Provisioned but not running | Image pull, or the platform rejected the revision | `az containerapp logs show -n ca-ct-uat-api -g rg-currencytracker-uat --type system --tail 100` |
 | `/health/live` 200 but `/health/ready` 503 | Postgres or Redis data-plane auth | `az containerapp revision list -n ca-ct-uat-api -g rg-currencytracker-uat -o table` |
-| Smoke rates leg 401 / 403 / wrong payload | **The pending `user` app role** — see §0 | `az account get-access-token --resource $env:SMOKE_TOKEN_RESOURCE --query accessToken -o tsv` |
+| Smoke rates leg 401 / `AADSTS65001` | **`MSApi` not configured as an API** — see §0 | `az account get-access-token --scope "api://e50b769e-1b9e-487d-baf5-7108f98935f2/access_as_user" --query accessToken -o tsv` |
+| Smoke rates leg 401 with a token in hand | Token is v1, or the wrong audience | Decode it — `iss` must end `/v2.0`, `aud` must be the bare GUID (§0) |
 | Green deploy but the image did not change | Expected. Terraform `ignore_changes` the image; only the pipeline moves it | `az containerapp show -n ca-ct-uat-api -g rg-currencytracker-uat --query "properties.template.containers[0].image" -o tsv` |
 | A second dispatch queues behind the first | Working as designed — `concurrency: deploy-uat`, `cancel-in-progress: false` | Wait. Deploys serialise so a half-applied environment is never abandoned |
 


### PR DESCRIPTION
## The wrong claim

`pipelines.md` §Manual prerequisites listed a pending **`user` app role, assigned to `gh-deploy-uat`**, as what blocks smoke leg 3. I repeated it in the UAT runbook, in the published artifact, and three times in conversation while debugging the first UAT deploys.

It is wrong in both halves:

- **The role does not exist.** `az ad app show --id e50b769e-… --query appRoles` returns `[]`. There was never anything to assign, so the prerequisite as written was not actionable.
- **The endpoint needs no role.** `Program.cs:213` applies `MapWolverineEndpoints(opts => opts.RequireAuthorizeOnAll())` — the default authenticated-user policy. Only `AdminIngestEndpoint.cs:31` carries `[Authorize(Policy = "admin")]`. `appRoleAssignmentRequired` is also `false`, so no assignment gates token issuance either.

## The actual blocker

`MSApi` was never configured as an API. Established by trying it rather than reasoning about it:

```
az account get-access-token --resource e50b769e-1b9e-487d-baf5-7108f98935f2
→ AADSTS65001: The user or administrator has not consented to use the
  application with ID '04b07795-...' named 'Microsoft Azure CLI'.
```

| Property | Actual | Consequence |
| --- | --- | --- |
| `identifierUris` | `[]` | nothing to request a token *for* |
| `api.oauth2PermissionScopes` | `[]` | no scope to consent to → `AADSTS65001` |
| `api.preAuthorizedApplications` | `[]` | Azure CLI can't mint a token silently |
| `api.requestedAccessTokenVersion` | `null` (v1) | `iss = sts.windows.net/<tid>/` |

Two independent blockers: nothing to request a token for, **and** the wrong token version even if there were. `Program.cs:148` sets `ValidIssuer = authAuthority`, an exact match against `…/v2.0`, so a v1 token fails on issuer before the audience is examined.

That last part is the one worth remembering: it surfaces as a plain 401, with nothing to suggest the token was the wrong *shape* rather than held by the wrong *principal*.

## Changes

| File | What |
| --- | --- |
| `docs/azure/bootstrap.md` | New §MSApi: the four required settings, the PATCH ordering trap, and the working token command |
| `docs/ci-cd/pipelines.md` | Prerequisite row replaced; a note records what it used to say and why that was wrong |
| `docs/ci-cd/uat-deploy-runbook.md` | Pre-flight rewritten around the real cause, with the token + claims-decoding recipe; two troubleshooting rows added |
| Artifact | Re-published to the same URL |

**The PATCH ordering trap** is worth calling out on its own: a `PATCH` to `api` replaces the whole object, so setting `preAuthorizedApplications` in a second call erases the scope created in the first unless the same scope `id` is reused. Easy to hit, confusing to diagnose.

## Also captured: the failure mode that cost two deploys

A new troubleshooting row for the shape we just lived through — a revision stuck `Activating` with `h: "None"` and **clean console logs, no errors**. That is a dependency *dropping* connections rather than refusing them: nothing logs because nothing fails, it simply never answers. The system log names it (`Probe of Readiness failed with timeout`), and for Postgres the cause was an empty firewall rule list.

That distinction — dropped vs refused — is what made #400 look ineffective when it wasn't.

## Not changed

`docs/auth.md` keeps its app-role guidance. Exposing `user` and `admin` roles is still right for `AdminIngestEndpoint`; the advice was simply mis-attributed as this failure's cause — by `pipelines.md` first, then by me. Creating those roles is deliberately out of scope here, since bundling it would re-blur the distinction this PR exists to draw.

Docs only — no workflow or infra change, merge whenever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
