### PR TITLE
feat(14.48): apply schema migrations from a Container Apps job before deploy

### DIFF
--- a/.github/workflows/_reusable-db-migrate.yml
+++ b/.github/workflows/_reusable-db-migrate.yml
@@ -1,0 +1,159 @@
+# _reusable-db-migrate.yml — apply the database schema before the new revision
+# goes live, by starting the environment's Container Apps migration job on a
+# pinned image DIGEST and blocking until the execution reaches a terminal state.
+#
+# Why a job and not `dotnet ef database update` on the runner: PROD Postgres has
+# no public endpoint (VNet-injected, private DNS), and neither deploy identity is
+# a registered Postgres administrator — the server is Entra-only. Both blockers
+# are independent, and neither is fixable from a runner without widening posture.
+# The job runs INSIDE the Container Apps environment as its own identity, which
+# modules/role-assignments registers as an administrator. See ADR 0018.
+#
+# This applies BOTH halves of the schema: EF Core migrations and Wolverine's
+# durability tables (created locally by AddResourceSetupOnStartup, which is
+# Development-only). The Worker image carries the entrypoint; `--migrate` is
+# baked into the job's args by Terraform, not passed from here.
+#
+# Fails closed. A non-Succeeded execution fails the caller before any revision
+# is updated — the ordering that stops a green apply from being followed by an
+# Api that 500s on every query.
+# Callers: deploy-uat.yml, deploy-prod.yml.
+name: _reusable-db-migrate
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: GitHub Environment (uat | prod).
+        type: string
+        required: true
+      image-tag:
+        description: Image tag whose migrations to apply (the commit SHA). Resolved
+          to a digest before the job is started, so the execution cannot drift onto
+          a retagged image.
+        type: string
+        required: true
+      assert-recent-backup:
+        description: Refuse to migrate unless the server has a completed backup in
+          the last 26 hours. True for PROD, where a bad migration is recovered by
+          restore and nothing else; false for UAT, which is disposable.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    name: migrate (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    # Comfortably above the job's own replica_timeout_in_seconds (1800s), so a
+    # migration that hits ITS ceiling reports that verdict rather than being
+    # cut off here with no status at all.
+    timeout-minutes: 45
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      # Schema rollback is not an operation. Image rollback is one digest swap
+      # (ADR 0015); a migration that commits is undone only by restoring. So
+      # PROD refuses to start one without a recent restore point to fall back
+      # to. geo_redundant_backup_enabled is off with a recorded reason, which
+      # makes the automated daily backup the whole safety net — worth asserting
+      # rather than assuming.
+      - name: Assert a recent backup exists
+        if: inputs.assert-recent-backup
+        shell: bash
+        env:
+          RG: ${{ vars.AZURE_RESOURCE_GROUP }}
+        run: |
+          set -euo pipefail
+
+          server=$(az postgres flexible-server list -g "$RG" --query "[0].name" -o tsv)
+          latest=$(az postgres flexible-server backup list \
+                     -g "$RG" -n "$server" \
+                     --query "max_by(@, &completedTime).completedTime" -o tsv)
+
+          if [ -z "$latest" ] || [ "$latest" = "None" ]; then
+            echo "::error::No completed backup found for ${server}; refusing to migrate PROD."
+            exit 1
+          fi
+
+          age_hours=$(( ( $(date -u +%s) - $(date -u -d "$latest" +%s) ) / 3600 ))
+          echo "latest backup: ${latest} (${age_hours}h old)"
+
+          if [ "$age_hours" -gt 26 ]; then
+            echo "::error::Latest ${server} backup is ${age_hours}h old (>26h); refusing to migrate PROD."
+            exit 1
+          fi
+
+      - name: Apply schema and gate on the execution verdict
+        shell: bash
+        env:
+          RG: ${{ vars.AZURE_RESOURCE_GROUP }}
+          TAG: ${{ inputs.image-tag }}
+        run: |
+          set -euo pipefail
+
+          job=$(az containerapp job list -g "$RG" \
+                  --query "[?ends_with(name, '-migrate')].name | [0]" -o tsv)
+          if [ -z "$job" ]; then
+            echo "::error::No *-migrate Container Apps job in ${RG}. Apply Terraform first."
+            exit 1
+          fi
+
+          # Pin by digest, not by tag. The Worker image is the one that carries
+          # the migrate entrypoint. Resolving here means the execution runs the
+          # exact bits this deploy is shipping, even if the tag moves.
+          acr=$(az acr list -g "$RG" --query "[0].name" -o tsv)
+          login_server=$(az acr list -g "$RG" --query "[0].loginServer" -o tsv)
+          digest=$(az acr manifest show-metadata \
+                     --registry "$acr" --name "worker:${TAG}" --query digest -o tsv)
+          image="${login_server}/worker@${digest}"
+          echo "migration image: ${image}"
+
+          # `update` then `start`, rather than `start --image`: it keeps the
+          # job's recorded image equal to what last ran, which is what you want
+          # when reading this back during an incident. Terraform ignore_changes
+          # means this does not fight the next plan.
+          az containerapp job update -n "$job" -g "$RG" --image "$image" --output none
+
+          execution=$(az containerapp job start -n "$job" -g "$RG" --query name -o tsv)
+          echo "execution: ${execution}"
+
+          # Poll to a terminal state. `job start` returns as soon as the
+          # execution is queued, so without this the deploy would race the
+          # schema it depends on.
+          status="Unknown"
+          for _ in $(seq 1 120); do
+            status=$(az containerapp job execution show \
+                       -n "$job" -g "$RG" --job-execution-name "$execution" \
+                       --query properties.status -o tsv 2>/dev/null || echo "Unknown")
+            case "$status" in
+              Succeeded|Failed|Cancelled) break ;;
+            esac
+            sleep 15
+          done
+
+          echo "final status: ${status}"
+
+          if [ "$status" != "Succeeded" ]; then
+            echo "::error::Schema migration ${execution} ended as ${status}; deploy not attempted."
+            # Diagnostics are best-effort: a CLI flag drift here must not mask
+            # the real failure above.
+            az containerapp job logs show \
+              -n "$job" -g "$RG" --container migrate \
+              --execution "$execution" --tail 200 || \
+              echo "::warning::Could not stream job logs; query the ContainerAppConsoleLogs_CL table for execution ${execution}."
+            exit 1
+          fi
+
+          echo "schema migration ${execution} succeeded"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -9,9 +9,11 @@
 # addressing the source by DIGEST pins content rather than a movable tag.
 #
 # NOTE: each prod job pends for reviewer approval + the wait timer as it reaches
-# the environment, so a release is three approvals. The approvals are the point;
-# the wait timer is the knob if it grates. The seams (apply / promote / deploy)
-# are separately re-runnable, which one mega-job would trade away for one click.
+# the environment, so a release is four approvals (14.48 added the schema
+# migration). The approvals are the point; the wait timer is the knob if it
+# grates. The seams (apply / promote / migrate / deploy) are separately
+# re-runnable, which one mega-job would trade away for one click — and the
+# migrate seam is the one you most want re-runnable on its own.
 name: deploy-prod
 
 on:
@@ -98,9 +100,26 @@ jobs:
               --force
           done
 
+  # 14.48 (ADR 0018) — after promote, because the job runs the PROD registry's
+  # copy of the Worker image and that copy does not exist until the import
+  # completes. Before deploy, because a revision must never front a schema that
+  # was not applied. Same mechanism as UAT; PROD adds the backup assertion,
+  # since here a bad migration is recovered by restore and nothing else.
+  migrate:
+    name: migrate
+    needs: promote
+    uses: ./.github/workflows/_reusable-db-migrate.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      environment: prod
+      image-tag: ${{ github.sha }}
+      assert-recent-backup: true
+
   deploy:
     name: deploy
-    needs: promote
+    needs: migrate
     uses: ./.github/workflows/_reusable-azure-deploy.yml
     permissions:
       contents: read
@@ -114,7 +133,7 @@ jobs:
 
   record:
     name: record
-    needs: [terraform, promote, deploy]
+    needs: [terraform, promote, migrate, deploy]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -129,6 +148,7 @@ jobs:
             echo "commit:     ${{ github.sha }}"
             echo "terraform:  ${{ needs.terraform.result }}"
             echo "promote:    ${{ needs.promote.result }}"
+            echo "migrate:    ${{ needs.migrate.result }}"
             echo "deploy:     ${{ needs.deploy.result }}"
             echo "actor:      ${{ github.actor }}"
           } | tee deploy-summary.txt
@@ -142,7 +162,7 @@ jobs:
 
   notify:
     name: notify
-    needs: [terraform, promote, deploy]
+    needs: [terraform, promote, migrate, deploy]
     if: failure() && vars.NOTIFICATIONS_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -94,12 +94,33 @@ jobs:
       environment: uat
       apply: true
 
+  # 14.48 (ADR 0018) — schema before revisions, never after. Terraform runs
+  # first because a fresh environment's migration job is created by it; the
+  # deploy runs last because it must not put a revision in front of a schema
+  # that was never applied. A failure here is a failed deploy with nothing
+  # moved, which is the cheap end of the failure spectrum.
+  migrate:
+    name: migrate
+    needs: [gate, terraform]
+    if: always() && needs.gate.result == 'success' && needs.terraform.result != 'failure'
+    uses: ./.github/workflows/_reusable-db-migrate.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      environment: uat
+      image-tag: ${{ needs.gate.outputs.image-tag }}
+
   deploy:
     name: deploy
-    needs: [gate, terraform]
-    # `always()` + an explicit failure check, so skipping the optional terraform
-    # job does not skip the deploy.
-    if: always() && needs.gate.result == 'success' && needs.terraform.result != 'failure'
+    needs: [gate, terraform, migrate]
+    # `always()` + explicit checks, so skipping the optional terraform job does
+    # not skip the deploy. `migrate` is required, not merely non-failing: it is
+    # skipped only if an upstream job it needs failed.
+    if: >-
+      always() && needs.gate.result == 'success'
+      && needs.terraform.result != 'failure'
+      && needs.migrate.result == 'success'
     uses: ./.github/workflows/_reusable-azure-deploy.yml
     permissions:
       contents: read
@@ -114,7 +135,7 @@ jobs:
   # upstream failed, hence always(). needs.*.result captures skipped too.
   record:
     name: record
-    needs: [gate, terraform, deploy]
+    needs: [gate, terraform, migrate, deploy]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -129,6 +150,7 @@ jobs:
             echo "image-tag:  ${{ needs.gate.outputs.image-tag || inputs.image-tag }}"
             echo "gate:       ${{ needs.gate.result }}"
             echo "terraform:  ${{ needs.terraform.result }}"
+            echo "migrate:    ${{ needs.migrate.result }}"
             echo "deploy:     ${{ needs.deploy.result }}"
             echo "actor:      ${{ github.actor }}"
             echo "ref:        ${{ github.ref }}"
@@ -148,7 +170,7 @@ jobs:
   # would park the message telling you UAT broke behind an approval gate.
   notify:
     name: notify
-    needs: [gate, terraform, deploy]
+    needs: [gate, terraform, migrate, deploy]
     if: failure() && vars.NOTIFICATIONS_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -16,7 +16,13 @@ signing key, with a 30-second clock skew. See ADR `0010-oidc-jwt-auth.md`.
 | `GET /api/v1/rates/latest`    | any authenticated caller         |
 | `GET /api/v1/rates/history`   | any authenticated caller         |
 | `POST /admin/ingest`          | the `admin` role (policy "admin")|
-| `/health`, `/alive`           | anonymous (liveness/readiness)   |
+| `/health/live`, `/health/ready` | anonymous (liveness/readiness) |
+
+> `/health` and `/alive` are the **Development-only** pair from
+> `ServiceDefaults/Extensions.cs` — that method guards them with
+> `app.Environment.IsDevelopment()`. Deployed, the paths are `/health/live` and
+> `/health/ready` (`Api/Program.cs`), which is what the container-app probes and
+> the deploy smoke legs call. This table named the dev pair until 14.48.
 
 ## Getting a token via curl (local Keycloak, dev only)
 
@@ -110,12 +116,20 @@ ADR 0010 is intact.
   touches auth), and then rejecting **every** token with a generic
   issuer-validation failure. With the guard it dies at startup naming both
   values, the revision never goes healthy, and `strict: true` fails the deploy.
-- **App roles are still required, and are still not automatic.** Expose `user`
-  and `admin` app roles on the API app registration, or every token
-  authenticates and no token authorises. The deploy identity also needs one
-  assigned (plus admin consent) before the authenticated smoke leg can obtain a
-  token — until then `az account get-access-token --resource <audience>` returns
-  `AADSTS500011` and the leg skips.
+- **App roles are needed for `/admin/ingest` only, and are still not
+  automatic.** Expose `user` and `admin` app roles on the API app registration
+  if you want the admin endpoint reachable. The two read endpoints need **no
+  role** — `RequireAuthorizeOnAll()` applies the default authenticated-user
+  policy, and a role-less token is correctly answered with 403 by
+  `/admin/ingest` and 200 by `/api/v1/rates/latest`.
+
+  > **Corrected 14.48.** This bullet used to claim the deploy identity needed an
+  > app-role assignment before a token could be obtained, and that
+  > `AADSTS500011` was the symptom of the missing assignment. Both halves were
+  > wrong. `AADSTS500011` is *resource principal not found* — it was raised
+  > because `MSApi` had no `identifierUris`, so `api://<client-id>` resolved to
+  > nothing. Configuring the registration as an API fixed it with no app role
+  > anywhere. See `docs/azure/bootstrap.md` §MSApi.
 
 ## Security posture (Phase 11.12 review)
 

--- a/docs/azure/bootstrap.md
+++ b/docs/azure/bootstrap.md
@@ -37,15 +37,22 @@ the audience `SMOKE_TOKEN_RESOURCE` requests a token for.
 | Field | Value |
 | ----- | ----- |
 | App (client) ID | `e50b769e-1b9e-487d-baf5-7108f98935f2` |
-| Object ID       | `6424a67b-d03b-4174-a7a7-f86e5b754bd3` |
-| Service principal object ID | `6424a67b-d03b-4174-a7a7-f86e5b754bd3` |
+| **Application** object ID | `f5914113-53a9-4d31-96bc-2d96c6751525` |
+| **Service principal** object ID | `6424a67b-d03b-4174-a7a7-f86e5b754bd3` |
 | `appRoleAssignmentRequired` | `false` |
 
-**It shipped bare and must be configured before any authenticated call
-succeeds** — discovered 2026-07-27 while trying to call
-`/api/v1/rates/latest` by hand. As created it had no `identifierUris`, no
-`oauth2PermissionScopes`, no `preAuthorizedApplications`, no `appRoles`, and
-`requestedAccessTokenVersion` unset:
+> **Both rows said `6424a67b-…` until 2026-07-28.** They are never the same
+> value: `az ad app show --id <client-id> --query id` returns the application
+> object, `az ad sp show` returns the service principal. Graph
+> `PATCH /applications/{id}` takes the **application** object id, so every call
+> aimed at the SP's id 404s. Resolve both live rather than trusting this table.
+
+**Configured 2026-07-28 — this section previously said it was blocking.** It
+shipped bare, discovered 2026-07-27 while trying to call `/api/v1/rates/latest`
+by hand: no `identifierUris`, no `oauth2PermissionScopes`, no
+`preAuthorizedApplications`, no `appRoles`, and `requestedAccessTokenVersion`
+unset. The four settings below are now applied and verified end to end — an
+unauthenticated call returns 401, an authenticated one reaches the handler.
 
 | Setting | Required value | Why |
 | ------- | -------------- | --- |
@@ -57,6 +64,25 @@ succeeds** — discovered 2026-07-27 while trying to call
 A `PATCH` to `api` replaces the whole object, so set the scope and the
 pre-authorized app in that order and reuse the same scope `id` in both calls —
 the second call otherwise silently erases the first.
+
+**Two calls are mandatory; merging them does not work.** The obvious
+simplification — one `PATCH` carrying the scope *and* its pre-authorization —
+is rejected outright:
+
+```
+InvalidValue: Property api.preAuthorizedApplications.delegatedPermissionIds
+has a Permission Id that cannot be found in the AppPermissions sets.
+```
+
+Graph validates `delegatedPermissionIds` against **persisted** scopes, not
+against the ones in the same request. So: call 1 sets
+`requestedAccessTokenVersion` + `oauth2PermissionScopes`; call 2 re-sends both
+*and* adds `preAuthorizedApplications`. The re-send is what survives the
+whole-object replace.
+
+The scope id in use is `9faf0955-99b2-4f50-b516-b022ce99a54d`. PowerShell mangles
+inline JSON — `\"` is not an escape there, and `az` sees the body split into
+separate arguments — so write the body to a file and pass `--body "@<path>"`.
 
 Fetching a token afterwards:
 

--- a/docs/ci-cd/pipelines.md
+++ b/docs/ci-cd/pipelines.md
@@ -47,13 +47,15 @@ graph LR
   Human[manual dispatch: image-tag] --> U[deploy-uat.yml]
   U --> UG[gate: verify tag exists in ACR]
   UG --> TFU[_reusable-terraform: uat, apply]
-  TFU --> DEPU[_reusable-azure-deploy: uat, strict=true]
+  TFU --> MIGU[_reusable-db-migrate: uat]
+  MIGU --> DEPU[_reusable-azure-deploy: uat, strict=true]
   DEPU --> UR[record 90d / notify on failure]
 
   Tag[git tag v*] --> P[deploy-prod.yml]
   P -.->|reviewer + wait, per job| TFP[_reusable-terraform: prod, apply]
   TFP --> PROM[promote: az acr import by digest, UAT -> PROD]
-  PROM --> DEPP[_reusable-azure-deploy: prod, http-smoke=false]
+  PROM --> MIGP[_reusable-db-migrate: prod, backup asserted]
+  MIGP --> DEPP[_reusable-azure-deploy: prod, http-smoke=false]
   DEPP --> PRREC[record 90d / notify on failure]
 ```
 
@@ -131,6 +133,12 @@ filter. Adding, renaming or removing a job in `ci.yml` now means editing that
 - **Deploys gate themselves.** `deploy-uat` requires a human dispatch and
   verifies the artifact exists before touching Azure; `deploy-prod` sits behind
   the `prod` environment's reviewer, wait timer, and `main`+`v*` branch policy.
+- **The schema gates the revision.** `_reusable-db-migrate` runs between
+  Terraform (UAT) or promote (PROD) and the deploy, and a non-`Succeeded` job
+  execution fails the run with **nothing deployed**. This ordering is the whole
+  point: before 14.48 an apply could go green and the Api would then 500 on
+  every query against a database that had no tables. Detection was never the
+  gap — the smoke leg already caught it, at the most expensive possible moment.
 
 ## Failure playbook
 
@@ -151,8 +159,8 @@ filter. Adding, renaming or removing a job in `ci.yml` now means editing that
 | `ci.yml`           | `pull_request`, `push` to `main`, dispatch         | PR gate: format, test+coverage, CodeQL, the two isolated integration suites, gitleaks, dependency-review |
 | `terraform-pr.yml` | `pull_request` on `infra/**`                       | Full IaC gate (UAT, plan only) + sticky plan comment                                                 |
 | `main-ci.yml`      | `push` to `main` (not `**.md` / `docs/**`)         | Certify the merge commit; build, Trivy-gate, and push `api:<sha>` / `worker:<sha>` to the UAT ACR    |
-| `deploy-uat.yml`   | `workflow_dispatch` (image-tag)                    | Verify the artifact, apply UAT, deploy that SHA, smoke                                                |
-| `deploy-prod.yml`  | `push` tags `v*`                                   | Behind the `prod` gate: apply PROD, promote by digest from the UAT ACR, deploy, control-plane verdict |
+| `deploy-uat.yml`   | `workflow_dispatch` (image-tag)                    | Verify the artifact, apply UAT, migrate the schema, deploy that SHA, smoke                            |
+| `deploy-prod.yml`  | `push` tags `v*`                                   | Behind the `prod` gate: apply PROD, promote by digest from the UAT ACR, migrate the schema, deploy, control-plane verdict |
 | `claude.yml`       | issue / review comments containing `@claude`       | Agent assist; unrelated to the delivery path                                                         |
 
 `ci.yml` still carries `push: branches: [main]`. Both it and `main-ci.yml` then
@@ -175,6 +183,7 @@ saying so.
 | `_reusable-acr-push.yml`          | OIDC → `az acr login` → push; outputs the digest                                                         | `image-name`, `tag`, `environment`                         |
 | `_reusable-terraform.yml`         | fmt/init/validate/tflint/checkov/plan[/apply] over `ARM_*` OIDC; checkov scans with the env's tfvars     | `working-dir`, `environment`, `apply`                      |
 | `_reusable-azure-deploy.yml`      | `az containerapp update --image` both apps → revision-health poll → smoke; strictness ladder             | `environment`, `image-tag`, `strict`, `http-smoke`         |
+| `_reusable-db-migrate.yml`        | starts the environment's Container Apps migration job on a pinned digest, polls to a terminal state      | `environment`, `image-tag`, `assert-recent-backup`         |
 
 ### Why the test work is split three ways
 
@@ -290,7 +299,20 @@ them can succeed. Record values in [`docs/azure/bootstrap.md`](../azure/bootstra
 | `SLACK_WEBHOOK_URL`                               | repo-level **secret**    | `notify` (both leaves)   | optional |
 | `NOTIFICATIONS_ENABLED`                           | repo-level **variable**  | `notify` kill-switch     | optional |
 | `SMOKE_TOKEN_RESOURCE`                            | `uat` env var            | smoke leg 3              | 14.47 ✅ |
-| `MSApi` configured as an API: `api://` identifier URI, `requestedAccessTokenVersion: 2`, an `access_as_user` scope, Azure CLI pre-authorised | Entra ID | smoke leg 3 | **pending** |
+| `MSApi` configured as an API: `api://` identifier URI, `requestedAccessTokenVersion: 2`, an `access_as_user` scope, Azure CLI pre-authorised | Entra ID | smoke leg 3 | 14.48 ✅ |
+
+**Applied 2026-07-28.** All four settings are now on the registration and a
+delegated token verifies against the deployed Api: `iss` ends `/v2.0`, `aud` is
+the bare client-id GUID, `ver` is `2.0`, `scp` is `access_as_user`. The
+unauthenticated call returns 401 and the authenticated one reaches the handler.
+See [`docs/azure/bootstrap.md`](../azure/bootstrap.md) §MSApi for the values and
+the Graph ordering trap.
+
+> **Still unverified: the leg's own token.** Smoke leg 3 requests
+> `SMOKE_TOKEN_RESOURCE` with `--resource` as the `gh-deploy-uat` **service
+> principal** — a client-credentials flow. `preAuthorizedApplications` is a
+> delegated-flow mechanism and does nothing for it. The verification above used
+> `--scope` as a user. The first `deploy-uat` dispatch is what settles it.
 
 **Corrected 2026-07-27.** This row used to read *"`user` app role on the API app
 registration, assigned to `gh-deploy-uat` + admin consent"*. That was wrong in
@@ -339,6 +361,7 @@ Where this implementation departs from the Phase 14.D plan, and why.
 | 14.26 | Dockerfile `HEALTHCHECK` | omitted | Container Apps ignores it, and the chiseled base ships no shell or curl to run one. Health is the platform probe seam. |
 | 14.39 | `SLACK_WEBHOOK_URL` env-scoped | repo-level secret | See above — an approval gate in front of a failure alert is backwards. |
 | 14.32 | `checkov -d .` scans the Terraform root | **`-d . --var-file envs/<env>/terraform.tfvars`** | Without a var-file checkov renders an environment-less config: every env-driven value is unresolved, so it scanned a shape neither environment deploys. It reported Key Vault public access as FAILED while PROD had already disabled it, and never evaluated the subnets at all (3 `CKV2_AZURE_31` findings invisible). The `environment` input now selects the scan envelope along with backend, tfvars and OIDC trust. |
+| 14.48 | Phase 14's deploy pipeline applies migrations "once, before the new revision goes live" (ADR 0004) | **never built at all, until now** | The step was recorded as a Phase 14 deliverable in ADR 0004 and Phase 14 closed without it. No workflow referenced `dotnet ef`; `MigrationRunner` is Development-only and both Azure environments run the `Production` profile. Found 2026-07-28 when the first authenticated call to UAT returned 500 with `42P01: relation "rate_snapshots" does not exist` — the database had no schema at all, and never had. `_reusable-db-migrate.yml` + `modules/container-app-job-migrate` are the implementation; ADR 0018 records why it is a Container Apps job and not a runner step. |
 | 14.32 | Terraform modules inherit the root `versions.tf` | **each module declares its own `terraform {}` block** | `tflint --recursive` lints every module directory as a standalone root, where the root `versions.tf` is out of scope; all 12 modules failed `terraform_required_version` + `terraform_required_providers`, and tflint exits 2 on warnings. The gate had never passed since it landed. |
 
 ---

--- a/docs/ci-cd/uat-deploy-runbook.md
+++ b/docs/ci-cd/uat-deploy-runbook.md
@@ -17,37 +17,26 @@ does not do](#what-this-pipeline-deliberately-does-not-do).
 
 ## 0. Pre-flight
 
-Four conditions decide whether a dispatch can succeed.
+Four conditions decide whether a dispatch can succeed. The first two were
+blockers and are now resolved; the last two are standing constraints.
 
-### Blocking: `MSApi` is not configured as an API
+### Resolved 2026-07-28: `MSApi` is configured as an API
 
-Smoke leg 3 requests a token for `SMOKE_TOKEN_RESOURCE` and calls
-`/api/v1/rates/latest`. That variable **is** set on the `uat` environment, so the
-leg runs — and because `deploy-uat.yml` sets `strict: true`, a failed smoke leg
-is a **failed deploy**, not a warning. It fails at the *last* step, after
-Terraform has applied and both apps have been updated.
+**This section described a blocker for one day. It is applied.** All four
+settings are on the registration — `identifierUris`, `requestedAccessTokenVersion: 2`,
+an `access_as_user` scope, and Azure CLI pre-authorised. The values, and the
+Graph ordering trap in applying them, are in
+[`../azure/bootstrap.md`](../azure/bootstrap.md) §MSApi. The **application**
+object id is `f5914113-53a9-4d31-96bc-2d96c6751525`; the `6424a67b-…` this file
+used to print is the service principal's, and no `PATCH` aimed at it will work.
 
-No token can be issued for this API today. Verified by trying it:
+What it looked like before, for recognition: `az login --scope
+"api://e50b769e-…/access_as_user"` failed with `AADSTS500011: The resource
+principal … was not found in the tenant`, because with no `identifierUris` the
+string named nothing Entra could resolve. A `--resource` request failed
+differently, with `AADSTS65001`, because nothing was consented.
 
-```
-az account get-access-token --resource e50b769e-1b9e-487d-baf5-7108f98935f2
-→ AADSTS65001: The user or administrator has not consented to use the
-  application with ID '04b07795-...' named 'Microsoft Azure CLI'.
-```
-
-App registration `MSApi` was created bare: no `identifierUris`, no
-`oauth2PermissionScopes`, no `preAuthorizedApplications`, and
-`requestedAccessTokenVersion` unset (which means **v1**). Two independent
-blockers — nothing to request a token *for*, and the wrong token version even if
-there were. `Program.cs` sets `ValidIssuer = authAuthority`, an exact match
-against `…/v2.0`, so a v1 token's `sts.windows.net` issuer 401s before the
-audience is even examined.
-
-The four settings, and the ordering trap in applying them, are in
-[`../azure/bootstrap.md`](../azure/bootstrap.md) §MSApi. Object id
-`6424a67b-d03b-4174-a7a7-f86e5b754bd3`.
-
-Once applied, this is the call — `--scope` (v2), never `--resource` (v1):
+This is the call — `--scope` (v2), never `--resource` (v1):
 
 ```powershell
 $token = az account get-access-token `
@@ -80,6 +69,32 @@ $p = $p.PadRight($p.Length + (4 - $p.Length % 4) % 4, '=')
 > and only `AdminIngestEndpoint` requires `admin`. The `user` / `admin` roles
 > [`../auth.md`](../auth.md) recommends are still worth having for the admin
 > endpoint; they were simply never what blocked this.
+
+### What the first authenticated call actually returned
+
+Worth knowing, because the next person will run the snippet above and see it.
+With a valid token, `/api/v1/rates/latest` returned **500**, and
+`/api/v1/rates/history` returned 500 as well:
+
+```
+Npgsql.PostgresException 42P01: relation "rate_snapshots" does not exist
+  at GetLatestRatesHandler.cs:53
+```
+
+The UAT database had **no schema at all** — no migration had ever been applied
+in Azure. ADR 0004 said "Phase 14's deploy pipeline applies migrations once,
+before the new revision goes live"; that step was never built. 14.48 builds it
+(`_reusable-db-migrate.yml`, ADR 0018), so a dispatch now applies the schema
+between Terraform and the deploy.
+
+Read the failures this way:
+
+| Response to an authenticated call | Means |
+| --- | --- |
+| 401 | Token problem. Decode it — `iss` and `aud`, above. Not the Api. |
+| 403 on `/admin/ingest` | **Correct.** The token carries no `admin` role. A 200 here would be the finding. |
+| 500 with `42P01` | Schema missing. The migrate job did not run, or ran against a different database. |
+| 200 or 404 | Auth and schema are both fine. 404 just means nothing has been ingested yet. |
 
 ### The other three
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -19,9 +19,14 @@ locals {
 # (14.18). The Username segment is the Entra ROLE name, which must equal the
 # principal_name each identity is registered under in modules/role-assignments.
 locals {
+  # 14.48 — `migrate` joins the two apps here, which is what generates its
+  # own `migrate-connectionstrings-currencytracker` vault secret. The job
+  # authenticates as its own Entra role because a Container Apps job cannot
+  # borrow another resource's system-assigned identity (ADR 0018).
   postgres_role_names = {
-    api    = "ca-api-identity"
-    worker = "ca-worker-identity"
+    api     = "ca-api-identity"
+    worker  = "ca-worker-identity"
+    migrate = "ca-migrate-identity"
   }
 
   connection_strings = merge(
@@ -274,13 +279,56 @@ module "container_app_worker" {
   tags = local.common_tags
 }
 
-# 14.24 — the least-privilege ledger: everything the two workload identities
+# 14.48 (ADR 0018) — the schema-migration job. Runs on demand, immediately
+# before a deploy updates the revisions, and never on a schedule. It carries no
+# cache secret: unlike the Worker (whose AddInfrastructure fail-fast forces the
+# value to be present), this process exits before any hosted service starts, so
+# the lazy cache factory is never touched.
+module "container_app_job_migrate" {
+  source = "./modules/container-app-job-migrate"
+
+  name_prefix                  = var.name_prefix
+  resource_group_name          = data.azurerm_resource_group.env.name
+  location                     = data.azurerm_resource_group.env.location
+  container_app_environment_id = module.container_apps_env.id
+  acr_login_server             = module.acr.login_server
+
+  # Same flip, same reason, as the two apps — safe because the AcrPull grant
+  # below has propagated. On a FRESH environment this is a two-pass apply:
+  # false with empty key_vault_secrets first, then true.
+  use_acr_registry = true
+
+  key_vault_secrets = {
+    "connectionstrings-currencytracker" = module.keyvault.secret_versionless_ids["migrate-connectionstrings-currencytracker"]
+  }
+
+  secret_env_vars = {
+    "ConnectionStrings__currencytracker" = "connectionstrings-currencytracker"
+  }
+
+  # DOTNET_ENVIRONMENT matches the Worker's, not the Api's ASPNETCORE_
+  # equivalent — this is the Worker image, and a job that resolved a different
+  # configuration than the host it migrates for would be migrating the wrong
+  # database with the right credentials.
+  env_vars = {
+    DOTNET_ENVIRONMENT        = "Production"
+    Azure__UseManagedIdentity = "true"
+  }
+
+  tags = local.common_tags
+}
+
+# 14.24 — the least-privilege ledger: everything the workload identities
 # may touch, one grant per line, scoped to single resources.
 module "role_assignments" {
   source = "./modules/role-assignments"
 
   api_principal_id    = module.container_app_api.principal_id
   worker_principal_id = module.container_app_worker.principal_id
+
+  # 14.48 — the migration job's identity. Third Postgres administrator; no
+  # Redis grant, because it opens no cache connection.
+  migrate_principal_id = module.container_app_job_migrate.principal_id
 
   acr_id                       = module.acr.id
   key_vault_id                 = module.keyvault.id

--- a/infra/terraform/modules/container-app-job-migrate/main.tf
+++ b/infra/terraform/modules/container-app-job-migrate/main.tf
@@ -1,0 +1,126 @@
+# The schema-migration job (ADR 0018). Terraform owns the job's shape; the
+# deploy pipeline owns the image — the same treaty the two container apps are
+# under, extended to a third resource rather than re-invented for it.
+#
+# Why a job at all: neither environment can be migrated from a CI runner. PROD
+# Postgres has no public endpoint (enable_public_network_access = false, VNet
+# injection + private DNS), and the deploy identities are not registered
+# database administrators. Running inside the environment solves both at once.
+#
+# Deliberate choices, each one load-bearing:
+#  - MANUAL trigger only. Nothing schedules this. The deploy workflow starts
+#    exactly one execution, before the new revision goes live.
+#  - parallelism = 1, replica_completion_count = 1. One replica applies the
+#    schema. Concurrent migration is the failure this forbids outright.
+#  - replica_retry_limit = 0. A half-applied migration must not be retried into
+#    a second partial application; a human reads the logs instead.
+#  - Its OWN system-assigned identity, and therefore a THIRD Postgres
+#    administrator registration in modules/role-assignments. A Container Apps
+#    job cannot borrow another resource's system-assigned identity, so "reuse
+#    the Worker's" was never available — see that module's ledger entry.
+#  - args = ["--migrate"], appended to the image ENTRYPOINT. The runtime image
+#    is chiseled and has no shell, so an args override is the only mechanism
+#    available; there is no `sh -c` to fall back on.
+
+# Provider requirements for this directory. The root module pins the same
+# constraints in versions.tf; these are the floor a caller must satisfy, and
+# what tflint reads when --recursive lints this module as a standalone root.
+terraform {
+  required_version = ">= 1.15"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+resource "azurerm_container_app_job" "migrate" {
+  name                         = "caj-${var.name_prefix}-migrate"
+  resource_group_name          = var.resource_group_name
+  location                     = var.location
+  container_app_environment_id = var.container_app_environment_id
+  workload_profile_name        = "Consumption"
+
+  # The ceiling on a single migration run. Generous enough for an index build
+  # on a cold database, short enough that a hung execution fails the deploy
+  # rather than parking it. Postgres DDL is transactional, so a replica killed
+  # at this boundary rolls back rather than leaving a half-applied schema.
+  replica_timeout_in_seconds = var.replica_timeout_in_seconds
+  replica_retry_limit        = 0
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  manual_trigger_config {
+    parallelism              = 1
+    replica_completion_count = 1
+  }
+
+  dynamic "registry" {
+    for_each = var.use_acr_registry ? [1] : []
+
+    content {
+      server   = var.acr_login_server
+      identity = "System"
+    }
+  }
+
+  dynamic "secret" {
+    for_each = var.key_vault_secrets
+
+    content {
+      name                = secret.key
+      key_vault_secret_id = secret.value
+      identity            = "System"
+    }
+  }
+
+  template {
+    container {
+      name   = "migrate"
+      image  = var.image
+      cpu    = 0.5
+      memory = "1Gi"
+
+      # Selects migrate-and-exit in the Worker host. The match is exact and
+      # ordinal on the application side: a typo here does NOT start a normal
+      # Worker, it is rejected by the JasperFx command line and the execution
+      # fails — which is the whole point of spelling it out in one place.
+      args = ["--migrate"]
+
+      dynamic "env" {
+        for_each = var.env_vars
+
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.secret_env_vars
+
+        content {
+          name        = env.key
+          secret_name = env.value
+        }
+      }
+    }
+  }
+
+  # The image treaty (ADR 0015, extended by ADR 0018). `az containerapp job
+  # start --image <digest>` is the only thing that moves this. Widening or
+  # removing this to make a plan clean re-points the job at the bootstrap
+  # placeholder, which would then "migrate" using an image containing no
+  # migrations.
+  lifecycle {
+    ignore_changes = [
+      template[0].container[0].image,
+    ]
+  }
+
+  tags = var.tags
+}

--- a/infra/terraform/modules/container-app-job-migrate/outputs.tf
+++ b/infra/terraform/modules/container-app-job-migrate/outputs.tf
@@ -1,0 +1,14 @@
+output "id" {
+  description = "Container App Job resource ID."
+  value       = azurerm_container_app_job.migrate.id
+}
+
+output "name" {
+  description = "Container App Job name (`az containerapp job start` in _reusable-db-migrate.yml targets it)."
+  value       = azurerm_container_app_job.migrate.name
+}
+
+output "principal_id" {
+  description = "Object ID of the system-assigned identity — the principal modules/role-assignments registers as a Postgres administrator and grants AcrPull and Key Vault Secrets User."
+  value       = azurerm_container_app_job.migrate.identity[0].principal_id
+}

--- a/infra/terraform/modules/container-app-job-migrate/variables.tf
+++ b/infra/terraform/modules/container-app-job-migrate/variables.tf
@@ -1,0 +1,65 @@
+variable "name_prefix" {
+  description = "Resource-name prefix for this environment (e.g. ct-uat)."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group the job is created in."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region. Required on azurerm_container_app_job, unlike azurerm_container_app which infers it from the environment."
+  type        = string
+}
+
+variable "container_app_environment_id" {
+  description = "Container Apps environment hosting the job (from modules/container-apps-env). Placing the job here is what gives it PROD's VNet integration and private DNS resolution for Postgres — the reason a CI runner cannot do this work."
+  type        = string
+}
+
+variable "acr_login_server" {
+  description = "Registry login server the job pulls from via its system identity."
+  type        = string
+}
+
+variable "use_acr_registry" {
+  description = "Declare the ACR registry credential on the job. Must stay false until the AcrPull grant exists for THIS job's identity — the same first-apply bootstrap cycle the two app modules document. Flip it in the same change that points `image` at the ACR."
+  type        = bool
+  default     = false
+}
+
+variable "image" {
+  description = "Bootstrap image only; the deploy pipeline owns the image after first apply (ignore_changes in main.tf). The placeholder contains no migrations, which is why the pipeline must always pass an explicit digest rather than relying on whatever the job last ran."
+  type        = string
+  default     = "mcr.microsoft.com/dotnet/samples:aspnetapp"
+}
+
+variable "replica_timeout_in_seconds" {
+  description = "Ceiling on one migration run. Default 1800 (30 min): long enough for an index build against a cold database, short enough that a hung execution fails the deploy instead of parking it. Raise only with a migration that demonstrably needs it."
+  type        = number
+  default     = 1800
+}
+
+variable "env_vars" {
+  description = "Plain environment variables (name => value). Must carry the same ASPNETCORE_ENVIRONMENT and Azure__UseManagedIdentity the Worker gets, or the job resolves a different configuration than the app it is migrating for."
+  type        = map(string)
+  default     = {}
+}
+
+variable "secret_env_vars" {
+  description = "Secret-backed environment variables (name => container-app secret name). Carries ConnectionStrings__currencytracker; the job needs no cache connection because it never opens one."
+  type        = map(string)
+  default     = {}
+}
+
+variable "key_vault_secrets" {
+  description = "Container-app secrets resolved from Key Vault via the system identity: name => Key Vault secret ID. Leave empty on a fresh environment's first apply — the identity is minted by this resource and its Key Vault Secrets User grant does not exist yet, so the reference would fail to resolve. Same two-pass bootstrap as the app modules."
+  type        = map(string)
+  default     = {}
+}
+
+variable "tags" {
+  description = "Tags applied to the job."
+  type        = map(string)
+}

--- a/infra/terraform/modules/role-assignments/main.tf
+++ b/infra/terraform/modules/role-assignments/main.tf
@@ -29,9 +29,22 @@ terraform {
 data "azurerm_client_config" "current" {}
 
 locals {
+  # 14.48 — `migrate` is the schema-migration job (ADR 0018). It is in this map
+  # because it needs all three of the grants below: AcrPull to pull the image it
+  # runs, Key Vault Secrets User to resolve its connection string, and a
+  # Postgres administrator registration to apply DDL. It is deliberately NOT in
+  # the Redis assignment further down — it opens no cache connection, the same
+  # asymmetry the Worker already has.
+  #
+  # It exists as a separate principal rather than reusing the Worker's because a
+  # Container Apps job cannot borrow another resource's system-assigned
+  # identity. The map key is load-bearing: principal_name below derives
+  # "ca-migrate-identity" from it, and that string must equal the Username
+  # segment of the connection string built in the root module.
   app_principals = {
-    api    = var.api_principal_id
-    worker = var.worker_principal_id
+    api     = var.api_principal_id
+    worker  = var.worker_principal_id
+    migrate = var.migrate_principal_id
   }
 }
 

--- a/infra/terraform/modules/role-assignments/variables.tf
+++ b/infra/terraform/modules/role-assignments/variables.tf
@@ -8,6 +8,11 @@ variable "worker_principal_id" {
   type        = string
 }
 
+variable "migrate_principal_id" {
+  description = "Object ID of the schema-migration job's system-assigned identity (14.48, ADR 0018). A distinct principal because a Container Apps job cannot borrow another resource's system-assigned identity. Receives AcrPull, Key Vault Secrets User and a Postgres administrator registration — but no Redis grant, because it opens no cache connection."
+  type        = string
+}
+
 variable "acr_id" {
   description = "Registry resource ID — AcrPull scope."
   type        = string

--- a/src/CurrencyTracker.Worker/CurrencyTracker.Worker.csproj
+++ b/src/CurrencyTracker.Worker/CurrencyTracker.Worker.csproj
@@ -18,6 +18,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="CurrencyTracker.Worker.UnitTests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\CurrencyTracker.Application\CurrencyTracker.Application.csproj" />
         <ProjectReference Include="..\CurrencyTracker.Infrastructure\CurrencyTracker.Infrastructure.csproj" />
         <ProjectReference Include="..\CurrencyTracker.Domain\CurrencyTracker.Domain.csproj" />

--- a/src/CurrencyTracker.Worker/Migrations/SchemaMigrator.cs
+++ b/src/CurrencyTracker.Worker/Migrations/SchemaMigrator.cs
@@ -1,0 +1,180 @@
+using CurrencyTracker.Infrastructure.Persistence;
+using JasperFx.Resources;
+using Microsoft.EntityFrameworkCore;
+
+namespace CurrencyTracker.Worker.Migrations;
+
+/// <summary>
+/// Migrate-and-exit mode for the Worker (ADR 0018). Applies pending EF Core
+/// migrations and provisions Wolverine's durability tables, then returns an
+/// exit code instead of starting a host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists because neither Azure environment can be migrated from a CI
+/// runner: PROD Postgres has no public endpoint, and the deploy identities are
+/// not registered database administrators. A Container Apps job runs this
+/// image, in the environment, under an identity that already is one.
+/// </para>
+/// <para>
+/// Both halves of the schema are applied here on purpose. EF Core owns the
+/// application tables; Wolverine owns the outbox/inbox tables in the
+/// <c>wolverine</c> schema, created locally by
+/// <c>AddResourceSetupOnStartup</c> — which is Development-only. Applying just
+/// the EF half would leave the Worker unable to start in Azure.
+/// </para>
+/// </remarks>
+internal static partial class SchemaMigrator
+{
+    /// <summary>The one argument that selects this mode.</summary>
+    private const string MigrateArgument = "--migrate";
+
+    /// <summary>Exit code for a database whose schema predates migration tracking.</summary>
+    private const int InconsistentHistoryExitCode = 2;
+
+    /// <summary>
+    /// Counts base tables in the <c>public</c> schema. The <c>Value</c> alias is
+    /// what <c>SqlQueryRaw&lt;T&gt;</c> binds a scalar projection to. The
+    /// <c>wolverine</c> schema is deliberately excluded: its tables say nothing
+    /// about whether EF's migration history is trustworthy.
+    /// </summary>
+    private const string CountPublicTablesSql = """
+        SELECT COUNT(*)::int AS "Value"
+        FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+        """;
+
+    /// <summary>
+    /// Determines whether the process was asked to migrate rather than run.
+    /// </summary>
+    /// <param name="args">The process arguments.</param>
+    /// <returns><see langword="true"/> only for an exact <c>--migrate</c> argument.</returns>
+    /// <remarks>
+    /// The match is ordinal and exact. A near-miss must fall through to the
+    /// JasperFx command line, which rejects it — the failure mode this prevents
+    /// is a mistyped flag starting a normal Worker inside a job that then runs
+    /// until its timeout and reports something misleading.
+    /// </remarks>
+    internal static bool IsRequested(string[] args) =>
+        Array.Exists(
+            args,
+            argument => string.Equals(argument, MigrateArgument, StringComparison.Ordinal)
+        );
+
+    /// <summary>
+    /// Applies the schema and returns a process exit code.
+    /// </summary>
+    /// <param name="host">The built host, not started.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>0 on success, 2 on an untracked pre-existing schema, 1 otherwise.</returns>
+    internal static async Task<int> RunAsync(IHost host, CancellationToken cancellationToken)
+    {
+        var logger = host
+            .Services.GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(SchemaMigrator).FullName!);
+
+        try
+        {
+            await using var scope = host.Services.CreateAsyncScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var applied = (
+                await dbContext.Database.GetAppliedMigrationsAsync(cancellationToken)
+            ).ToList();
+
+            // A schema that exists without a migration history is the one state
+            // MigrateAsync cannot resolve: it would replay InitialCreate and
+            // fail on CREATE TABLE. Refuse it with a distinct exit code rather
+            // than emitting a confusing 42P07 from inside EF.
+            if (applied.Count == 0)
+            {
+                var publicTables = await dbContext
+                    .Database.SqlQueryRaw<int>(CountPublicTablesSql)
+                    .SingleAsync(cancellationToken);
+
+                if (publicTables > 0)
+                {
+                    LogInconsistentHistory(logger, publicTables);
+                    return InconsistentHistoryExitCode;
+                }
+            }
+
+            var pending = (
+                await dbContext.Database.GetPendingMigrationsAsync(cancellationToken)
+            ).ToList();
+
+            if (pending.Count == 0)
+            {
+                LogNoPendingMigrations(logger, applied.Count);
+            }
+            else
+            {
+                LogApplyingMigrations(logger, pending.Count, pending);
+                await dbContext.Database.MigrateAsync(cancellationToken);
+                LogMigrationsApplied(logger, pending.Count);
+            }
+
+            // Wolverine's outbox/inbox tables. Idempotent — it creates what is
+            // missing and leaves what exists.
+            LogProvisioningResources(logger);
+            await host.SetupResources();
+            LogResourcesProvisioned(logger);
+
+            return 0;
+        }
+        catch (Exception exception)
+        {
+            LogMigrationFailed(logger, exception);
+            return 1;
+        }
+    }
+
+    [LoggerMessage(
+        EventId = 1100,
+        Level = LogLevel.Information,
+        Message = "Applying {PendingCount} pending migration(s): {Migrations}."
+    )]
+    private static partial void LogApplyingMigrations(
+        ILogger logger,
+        int pendingCount,
+        IReadOnlyList<string> migrations
+    );
+
+    [LoggerMessage(
+        EventId = 1101,
+        Level = LogLevel.Information,
+        Message = "Applied {PendingCount} migration(s)."
+    )]
+    private static partial void LogMigrationsApplied(ILogger logger, int pendingCount);
+
+    [LoggerMessage(
+        EventId = 1102,
+        Level = LogLevel.Information,
+        Message = "No pending migrations; {AppliedCount} already applied."
+    )]
+    private static partial void LogNoPendingMigrations(ILogger logger, int appliedCount);
+
+    [LoggerMessage(
+        EventId = 1103,
+        Level = LogLevel.Information,
+        Message = "Provisioning Wolverine durability resources."
+    )]
+    private static partial void LogProvisioningResources(ILogger logger);
+
+    [LoggerMessage(
+        EventId = 1104,
+        Level = LogLevel.Information,
+        Message = "Wolverine durability resources provisioned."
+    )]
+    private static partial void LogResourcesProvisioned(ILogger logger);
+
+    [LoggerMessage(
+        EventId = 1105,
+        Level = LogLevel.Error,
+        Message = "Refusing to migrate: the database has {TableCount} table(s) in the public schema but no EF migration history. Restore from backup or baseline __EFMigrationsHistory by hand."
+    )]
+    private static partial void LogInconsistentHistory(ILogger logger, int tableCount);
+
+    [LoggerMessage(EventId = 1106, Level = LogLevel.Error, Message = "Schema migration failed.")]
+    private static partial void LogMigrationFailed(ILogger logger, Exception exception);
+}

--- a/src/CurrencyTracker.Worker/Program.cs
+++ b/src/CurrencyTracker.Worker/Program.cs
@@ -10,6 +10,7 @@ using CurrencyTracker.Infrastructure;
 using CurrencyTracker.Infrastructure.Persistence; // ApplicationDataSource (14.44)
 using CurrencyTracker.ServiceDefaults;
 using CurrencyTracker.Worker.Configuration;
+using CurrencyTracker.Worker.Migrations; // 14.48: migrate-and-exit (ADR 0018)
 using CurrencyTracker.Worker.Scheduling;
 using JasperFx; // RunJasperFxCommands (from 12.1)
 using JasperFx.Resources; // AddResourceSetupOnStartup (see version note)
@@ -182,8 +183,29 @@ if (builder.Environment.IsDevelopment())
 //var host = builder.Build();
 //host.Run();
 
+var host = builder.Build();
+
+// 14.48 (ADR 0018) — migrate-and-exit. A Container Apps job runs THIS image
+// with `--migrate` before the new revision goes live, because neither Azure
+// environment can be migrated from a CI runner: PROD Postgres has no public
+// endpoint, and the deploy identities are not database administrators. The
+// check is ahead of RunJasperFxCommands because `--migrate` is not a JasperFx
+// verb; an inexact flag falls through and is rejected there, which is the
+// intended failure — never a normal host started inside a job.
+if (SchemaMigrator.IsRequested(args))
+{
+    using var migrationCancellation = new CancellationTokenSource();
+    Console.CancelKeyPress += (_, eventArgs) =>
+    {
+        eventArgs.Cancel = true;
+        migrationCancellation.Cancel();
+    };
+
+    return await SchemaMigrator.RunAsync(host, migrationCancellation.Token);
+}
+
 // Forward args to the JasperFx command line so the `describe` / `codegen`
 // verbs work in this host, exactly as Phase 5.9 did for the Api. With no
 // command argument this behaves identically to host.Run() — the AppHost
 // launches the Worker with no args, so production startup is unchanged.
-return await builder.Build().RunJasperFxCommands(args);
+return await host.RunJasperFxCommands(args);

--- a/tests/CurrencyTracker.Worker.UnitTests/Migrations/SchemaMigratorTests.cs
+++ b/tests/CurrencyTracker.Worker.UnitTests/Migrations/SchemaMigratorTests.cs
@@ -1,0 +1,56 @@
+using CurrencyTracker.Worker.Migrations;
+
+namespace CurrencyTracker.Worker.UnitTests.Migrations;
+
+/// <summary>
+/// Tests for <see cref="SchemaMigrator.IsRequested"/>, the argument guard that
+/// decides whether this process migrates and exits or starts as a normal
+/// Worker. ADR 0018 requires the match to be exact: a near-miss must fall
+/// through to the JasperFx command line and fail there, never silently start a
+/// long-running host inside a Container Apps job that then burns its timeout.
+/// </summary>
+public sealed class SchemaMigratorTests
+{
+    [Fact]
+    public void IsRequested_is_true_for_the_exact_argument()
+    {
+        var requested = SchemaMigrator.IsRequested(["--migrate"]);
+
+        requested.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRequested_is_true_when_the_argument_appears_among_others()
+    {
+        var requested = SchemaMigrator.IsRequested(["--environment", "Production", "--migrate"]);
+
+        requested.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRequested_is_false_for_no_arguments()
+    {
+        var requested = SchemaMigrator.IsRequested([]);
+
+        requested.Should().BeFalse();
+    }
+
+    // Each of these is a plausible way to get the flag wrong in a Terraform
+    // args list or in an `az containerapp job start` override. None may be
+    // treated as a migration request.
+    [Theory]
+    [InlineData("--migrat")]
+    [InlineData("--migrates")]
+    [InlineData("migrate")]
+    [InlineData("-migrate")]
+    [InlineData("--Migrate")]
+    [InlineData("--MIGRATE")]
+    [InlineData("--migrate=true")]
+    [InlineData(" --migrate")]
+    public void IsRequested_is_false_for_a_near_miss(string argument)
+    {
+        var requested = SchemaMigrator.IsRequested([argument]);
+
+        requested.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Why

ADR 0004 recorded that *"Phase 14's deploy pipeline applies migrations once, before the new revision goes live."* **That step was never built.** No workflow references `dotnet ef`; `MigrationRunner` is registered only when `env.IsDevelopment()`, and both Azure environments run the `Production` profile. Nothing has ever applied a migration in Azure.

It surfaced on 2026-07-28. With authentication working end to end for the first time, both read endpoints returned 500 from UAT:

```
Npgsql.PostgresException 42P01: relation "rate_snapshots" does not exist
  at GetLatestRatesHandler.cs:53
```

The UAT database has no schema at all.

## Why not `dotnet ef database update` on the runner

Two independent blockers, neither fixable without a posture change:

- **PROD Postgres has no public endpoint.** `envs/prod/terraform.tfvars` sets `enable_public_network_access = false`; the server is VNet-injected with a private DNS zone. There is no address a hosted runner could be allowed.
- **The server is Entra-only.** `password_auth_enabled = false`, and the only registered administrators are `ca-api-identity` and `ca-worker-identity`. Contributor on the resource group does not make a deploy identity a database principal.

So the migration runs *inside* the Container Apps environment.

## What this adds

| Piece | What it does |
| --- | --- |
| `Worker/Migrations/SchemaMigrator.cs` | `--migrate` mode: applies EF migrations **and** provisions Wolverine's durability tables, then exits with a status code |
| `modules/container-app-job-migrate` | Manual-trigger job, `parallelism 1`, `replica_retry_limit 0`, runs the promoted Worker image with `args = ["--migrate"]` |
| `role-assignments` | The job's identity as a third principal — AcrPull, Key Vault Secrets User, Postgres admin. **No Redis grant**; it opens no cache connection |
| `_reusable-db-migrate.yml` | Starts the job on a pinned **digest**, polls to a terminal state, fails closed |
| `deploy-uat` / `deploy-prod` | `migrate` between terraform/promote and deploy |

**Both halves of the schema.** `AddResourceSetupOnStartup()` is Development-only, so Wolverine's outbox tables were as absent from Azure as the EF ones. Applying only EF migrations would have left the Worker unable to start.

**Ordering is the point.** A failed migration fails the deploy with *nothing moved*. Before this, an apply went green and the Api then 500'd on every query — detection was never the gap, the smoke leg already caught it at the most expensive possible moment.

**PROD asserts a recent backup.** Image rollback is one digest swap; schema rollback is a restore and nothing else. `geo_redundant_backup_enabled` is off with a recorded reason, so the daily backup is the whole safety net — worth asserting rather than assuming.

## Doc corrections from the same investigation

- `bootstrap.md` — MSApi is **configured**, not blocking. Its "Object ID" row held the **service principal's** id; Graph `PATCH /applications/{id}` needs the application object (`f5914113-…`), so every call aimed at the old value 404s. Also records that Graph rejects a scope and its pre-authorization in one PATCH.
- `uat-deploy-runbook.md` — §0's blocker is resolved; adds a table for reading an authenticated call's response (401 vs 403 vs `42P01` vs 200/404).
- `auth.md` — listed the **Development-only** `/health` + `/alive`; deployed paths are `/health/live` and `/health/ready`. Also retracts the claim that `AADSTS500011` came from a missing app role — it is *resource principal not found*, caused by the absent `identifierUris`.
- `pipelines.md` — graph, workflow tables, and a `14.48` drift row.

## Not in this PR

- **ADR 0018** is drafted and proposed separately, per the agreed split on protected files.
- **AGENTS.md** entries (§Gotchas, §Don't, §Current phase) were listed for manual application rather than edited here.
- **`GetRateHistoryHandler.cs:25-26`** calls `.Value` on a `Result` unguarded, so a missing `quote` parameter yields a 422 leaking `"Cannot access Value on a Failure result."` instead of a 400. Real bug, out of scope — separate issue.
- **Smoke leg 3's own token** is still unverified: it requests `SMOKE_TOKEN_RESOURCE` with `--resource` as a *service principal*, which `preAuthorizedApplications` does not affect. Today's verification used `--scope` as a user. The first dispatch settles it.

## Verification

`csharpier check` clean · `dotnet format --verify-no-changes` clean · Release build **0 warnings** · `terraform fmt -recursive -check` + `validate` clean · **289 tests pass**, including all three container suites and the architecture tests.

Not yet exercised against Azure — the job resource does not exist until this applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
