### PR TITLE
fix(14.48): run the migration job as a user-assigned identity

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -279,6 +279,30 @@ module "container_app_worker" {
   tags = local.common_tags
 }
 
+# 14.48 — the migration job's identity, deliberately NOT declared inside
+# modules/container-app-job-migrate, and deliberately USER-assigned while both
+# apps are system-assigned.
+#
+# A system-assigned identity is minted BY the resource that uses it, so its
+# grants cannot precede its creation. That is survivable for the two container
+# apps (they bootstrap in two passes, as their modules document) but not here: a
+# Container Apps job provisions a revision at CREATE time, pulling the image and
+# resolving Key Vault references before any grant exists. The first apply of
+# this job failed exactly there — "Failed to provision revision ... Operation
+# expired", after a 20-minute poll.
+#
+# Hoisting the identity out breaks the cycle: it exists first, role_assignments
+# grants it, and the job attaches it. It cannot live in the job module, because
+# role_assignments would then depend on the very module that has to depend on
+# role_assignments. One apply, repeatable on a clean tenant — which matters
+# because deploy-uat runs `terraform apply` unattended.
+resource "azurerm_user_assigned_identity" "migrate" {
+  name                = "id-${var.name_prefix}-migrate"
+  resource_group_name = data.azurerm_resource_group.env.name
+  location            = data.azurerm_resource_group.env.location
+  tags                = local.common_tags
+}
+
 # 14.48 (ADR 0018) — the schema-migration job. Runs on demand, immediately
 # before a deploy updates the revisions, and never on a schedule. It carries no
 # cache secret: unlike the Worker (whose AddInfrastructure fail-fast forces the
@@ -292,10 +316,11 @@ module "container_app_job_migrate" {
   location                     = data.azurerm_resource_group.env.location
   container_app_environment_id = module.container_apps_env.id
   acr_login_server             = module.acr.login_server
+  identity_id                  = azurerm_user_assigned_identity.migrate.id
 
-  # Same flip, same reason, as the two apps — safe because the AcrPull grant
-  # below has propagated. On a FRESH environment this is a two-pass apply:
-  # false with empty key_vault_secrets first, then true.
+  # No two-pass bootstrap here, unlike the apps: the identity above already
+  # holds AcrPull and Key Vault Secrets User by the time this resource is
+  # created, because depends_on forces that order.
   use_acr_registry = true
 
   key_vault_secrets = {
@@ -313,9 +338,21 @@ module "container_app_job_migrate" {
   env_vars = {
     DOTNET_ENVIRONMENT        = "Production"
     Azure__UseManagedIdentity = "true"
+
+    # ApplicationDataSource builds a bare DefaultAzureCredential, which resolves
+    # the SYSTEM-assigned identity unless this names the user-assigned one. The
+    # job has no system-assigned identity at all, so without this line the token
+    # request fails and every connection is refused — with a message about
+    # managed identity that says nothing about which one.
+    AZURE_CLIENT_ID = azurerm_user_assigned_identity.migrate.client_id
   }
 
   tags = local.common_tags
+
+  # The grants must exist before the job provisions its revision. Terraform sees
+  # no data dependency between them — the job consumes the identity, not the
+  # role assignments — so the ordering has to be stated.
+  depends_on = [module.role_assignments]
 }
 
 # 14.24 — the least-privilege ledger: everything the workload identities
@@ -327,8 +364,10 @@ module "role_assignments" {
   worker_principal_id = module.container_app_worker.principal_id
 
   # 14.48 — the migration job's identity. Third Postgres administrator; no
-  # Redis grant, because it opens no cache connection.
-  migrate_principal_id = module.container_app_job_migrate.principal_id
+  # Redis grant, because it opens no cache connection. Read from the standalone
+  # identity resource, not from the job module — that is what lets these grants
+  # be created BEFORE the job that needs them.
+  migrate_principal_id = azurerm_user_assigned_identity.migrate.principal_id
 
   acr_id                       = module.acr.id
   key_vault_id                 = module.keyvault.id

--- a/infra/terraform/modules/container-app-job-migrate/main.tf
+++ b/infra/terraform/modules/container-app-job-migrate/main.tf
@@ -14,10 +14,15 @@
 #    schema. Concurrent migration is the failure this forbids outright.
 #  - replica_retry_limit = 0. A half-applied migration must not be retried into
 #    a second partial application; a human reads the logs instead.
-#  - Its OWN system-assigned identity, and therefore a THIRD Postgres
-#    administrator registration in modules/role-assignments. A Container Apps
-#    job cannot borrow another resource's system-assigned identity, so "reuse
-#    the Worker's" was never available — see that module's ledger entry.
+#  - A USER-assigned identity, passed in, while both container apps use
+#    system-assigned ones. Not a style choice: a job provisions its revision at
+#    CREATE time, so a system-assigned identity — minted by this very resource —
+#    could not hold the AcrPull and Key Vault grants the provisioning needs. The
+#    first apply died there after a 20-minute poll. The identity is declared in
+#    the root module so it can be granted first; see the comment on
+#    azurerm_user_assigned_identity.migrate for why it cannot live here.
+#    It is a THIRD Postgres administrator either way — a job cannot borrow
+#    another resource's identity, so "reuse the Worker's" was never available.
 #  - args = ["--migrate"], appended to the image ENTRYPOINT. The runtime image
 #    is chiseled and has no shell, so an args override is the only mechanism
 #    available; there is no `sh -c` to fall back on.
@@ -51,7 +56,8 @@ resource "azurerm_container_app_job" "migrate" {
   replica_retry_limit        = 0
 
   identity {
-    type = "SystemAssigned"
+    type         = "UserAssigned"
+    identity_ids = [var.identity_id]
   }
 
   manual_trigger_config {
@@ -59,12 +65,14 @@ resource "azurerm_container_app_job" "migrate" {
     replica_completion_count = 1
   }
 
+  # `identity` here takes the user-assigned identity's RESOURCE ID, where the
+  # container apps pass the literal "System". Same field, different grammar.
   dynamic "registry" {
     for_each = var.use_acr_registry ? [1] : []
 
     content {
       server   = var.acr_login_server
-      identity = "System"
+      identity = var.identity_id
     }
   }
 
@@ -74,7 +82,7 @@ resource "azurerm_container_app_job" "migrate" {
     content {
       name                = secret.key
       key_vault_secret_id = secret.value
-      identity            = "System"
+      identity            = var.identity_id
     }
   }
 

--- a/infra/terraform/modules/container-app-job-migrate/outputs.tf
+++ b/infra/terraform/modules/container-app-job-migrate/outputs.tf
@@ -8,7 +8,6 @@ output "name" {
   value       = azurerm_container_app_job.migrate.name
 }
 
-output "principal_id" {
-  description = "Object ID of the system-assigned identity — the principal modules/role-assignments registers as a Postgres administrator and grants AcrPull and Key Vault Secrets User."
-  value       = azurerm_container_app_job.migrate.identity[0].principal_id
-}
+# No principal_id output. The identity is user-assigned and declared in the root
+# module, which is where modules/role-assignments reads it from — exporting it
+# back out of here would reintroduce the dependency cycle this design removed.

--- a/infra/terraform/modules/container-app-job-migrate/variables.tf
+++ b/infra/terraform/modules/container-app-job-migrate/variables.tf
@@ -19,7 +19,12 @@ variable "container_app_environment_id" {
 }
 
 variable "acr_login_server" {
-  description = "Registry login server the job pulls from via its system identity."
+  description = "Registry login server the job pulls from via the identity below."
+  type        = string
+}
+
+variable "identity_id" {
+  description = "Resource ID of the USER-assigned managed identity the job runs as, declared in the root module so its grants exist before this resource is created. User-assigned rather than system-assigned because a job provisions its revision at create time: a system-assigned identity is minted by the resource itself and so cannot already hold AcrPull or Key Vault Secrets User, which is what made the first apply fail. Also the value of the registry and secret `identity` fields, which take a resource ID here where a container app takes the literal \"System\"."
   type        = string
 }
 

--- a/infra/terraform/modules/role-assignments/main.tf
+++ b/infra/terraform/modules/role-assignments/main.tf
@@ -37,10 +37,13 @@ locals {
   # asymmetry the Worker already has.
   #
   # It exists as a separate principal rather than reusing the Worker's because a
-  # Container Apps job cannot borrow another resource's system-assigned
-  # identity. The map key is load-bearing: principal_name below derives
-  # "ca-migrate-identity" from it, and that string must equal the Username
-  # segment of the connection string built in the root module.
+  # Container Apps job cannot borrow another resource's identity, and it is
+  # USER-assigned (declared in the root module) rather than system-assigned so
+  # that these grants can be created BEFORE the job that needs them — a job
+  # provisions its revision at create time and pulls its image then. The map key
+  # is load-bearing: principal_name below derives "ca-migrate-identity" from it,
+  # and that string must equal the Username segment of the connection string
+  # built in the root module.
   app_principals = {
     api     = var.api_principal_id
     worker  = var.worker_principal_id

--- a/infra/terraform/modules/role-assignments/variables.tf
+++ b/infra/terraform/modules/role-assignments/variables.tf
@@ -9,7 +9,7 @@ variable "worker_principal_id" {
 }
 
 variable "migrate_principal_id" {
-  description = "Object ID of the schema-migration job's system-assigned identity (14.48, ADR 0018). A distinct principal because a Container Apps job cannot borrow another resource's system-assigned identity. Receives AcrPull, Key Vault Secrets User and a Postgres administrator registration — but no Redis grant, because it opens no cache connection."
+  description = "Object ID of the schema-migration job's USER-assigned identity (14.48, ADR 0018), read from the standalone identity resource in the root module rather than from the job. That is the whole point: these grants must exist before the job provisions, and a job's system-assigned identity would not exist until it did. Receives AcrPull, Key Vault Secrets User and a Postgres administrator registration — but no Redis grant, because it opens no cache connection."
   type        = string
 }
 


### PR DESCRIPTION
## What happened

The first UAT apply of #403 failed after a 20-minute poll:

```
ContainerAppOperationError: Failed to provision revision for container app
'caj-ct-uat-migrate'. Error details: Operation expired.
```

I gave the job a **system-assigned** identity on the expectation that a job — unlike a container app — provisions nothing until an execution starts, so its AcrPull and Key Vault grants could be created in the same apply. I flagged that as reasoning rather than verification when handing over the plan. It was wrong.

A Container Apps job **provisions a revision at create time**, pulling its image and resolving Key Vault references then. A system-assigned identity is minted by the resource that uses it, so at that moment it held no grants and could do neither.

## Why not the two-pass bootstrap

`container-app-api` and `container-app-worker` survive the identical cycle by applying once with `use_acr_registry = false` and `key_vault_secrets = {}`, then reverting. Rejected here: **`deploy-uat` runs `terraform apply` unattended.** A fresh environment would need a human to edit tracked Terraform, apply, revert, and apply again — which turns `bootstrap.md`'s "re-run them by hand to reproduce the stack in a clean tenant" into a manual procedure for the one resource that gates every deploy.

## The fix

Hoist the identity into a standalone `azurerm_user_assigned_identity` in the root module:

```
azurerm_user_assigned_identity.migrate     principal_id available immediately
   ↓
module.role_assignments["migrate"]          AcrPull + KV Secrets User + PG admin
   ↓  (explicit depends_on)
module.container_app_job_migrate            identity attached, grants already live
```

One apply, repeatable on a clean tenant.

**It cannot live inside the job module.** `role_assignments` must depend on the identity, and the job must depend on `role_assignments` — declaring the identity in the module makes those a module-scope cycle. That's why the root, which otherwise only composes modules, now declares one bare resource. The comment there says so.

**Also sets `AZURE_CLIENT_ID` on the job.** `ApplicationDataSource.cs:101` builds a bare `DefaultAzureCredential`, which resolves the *system-assigned* identity unless told otherwise — and the job now has none. Without this the failure is a managed-identity error that names no identity.

## Before applying

The failed apply left an orphan that Terraform does not track:

```powershell
az containerapp job delete -n caj-ct-uat-migrate -g rg-currencytracker-uat --yes
```

The Key Vault secret `migrate-connectionstrings-currencytracker` *was* created and is in state — leave it.

## Verification

`terraform fmt -recursive` + `validate` clean. Not applied yet — that's the next step, and the real test.

No application code changed, so the .NET gates are unaffected by this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
