### PR TITLE
fix(14.48): give the migration job the cache connection string

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -304,10 +304,17 @@ resource "azurerm_user_assigned_identity" "migrate" {
 }
 
 # 14.48 (ADR 0018) — the schema-migration job. Runs on demand, immediately
-# before a deploy updates the revisions, and never on a schedule. It carries no
-# cache secret: unlike the Worker (whose AddInfrastructure fail-fast forces the
-# value to be present), this process exits before any hosted service starts, so
-# the lazy cache factory is never touched.
+# before a deploy updates the revisions, and never on a schedule.
+#
+# It carries the cache connection string for exactly the reason the Worker block
+# below states: AddInfrastructure() fail-fasts on a missing
+# ConnectionStrings__cache in EVERY host, at builder-configuration time. This
+# job first shipped without it, on the theory that a process which exits before
+# any hosted service starts never touches the lazy cache factory. True, and
+# irrelevant — the guard runs at Program.cs's AddInfrastructure() call, long
+# before that. The execution died there with
+# "ConnectionStrings__cache is not configured". Present and never used, as in
+# the Worker; still no Redis grant, because it still opens no connection.
 module "container_app_job_migrate" {
   source = "./modules/container-app-job-migrate"
 
@@ -325,10 +332,12 @@ module "container_app_job_migrate" {
 
   key_vault_secrets = {
     "connectionstrings-currencytracker" = module.keyvault.secret_versionless_ids["migrate-connectionstrings-currencytracker"]
+    "connectionstrings-cache"           = module.keyvault.secret_versionless_ids["connectionstrings-cache"]
   }
 
   secret_env_vars = {
     "ConnectionStrings__currencytracker" = "connectionstrings-currencytracker"
+    "ConnectionStrings__cache"           = "connectionstrings-cache"
   }
 
   # DOTNET_ENVIRONMENT matches the Worker's, not the Api's ASPNETCORE_

--- a/infra/terraform/modules/container-app-job-migrate/variables.tf
+++ b/infra/terraform/modules/container-app-job-migrate/variables.tf
@@ -53,7 +53,7 @@ variable "env_vars" {
 }
 
 variable "secret_env_vars" {
-  description = "Secret-backed environment variables (name => container-app secret name). Carries ConnectionStrings__currencytracker; the job needs no cache connection because it never opens one."
+  description = "Secret-backed environment variables (name => container-app secret name). Must carry BOTH ConnectionStrings__currencytracker and ConnectionStrings__cache. The cache one is not optional even though this job never opens a cache connection: AddInfrastructure() fail-fasts on its absence at builder-configuration time, before any hosted service starts, so a job without it dies at startup with \"ConnectionStrings__cache is not configured\". Same present-and-unused arrangement the Worker has."
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
## What happened

The first real execution of the migration job failed at startup:

```
Unhandled exception. System.InvalidOperationException:
ConnectionStrings__cache is not configured.
  at CurrencyTracker.Infrastructure.DependencyInjection.AddInfrastructure(...)
     DependencyInjection.cs:line 72
  at Program.<Main>$(String[] args) Program.cs:line 45
```

I omitted the cache secret from the job on the reasoning that a process which exits before any hosted service starts never touches the lazy `ConnectionMultiplexerFactory`. That's true, and irrelevant — the fail-fast lives in `AddInfrastructure()` itself, at builder-configuration time, which `Program.cs` calls before anything else runs.

The Worker's block in `main.tf` already said so:

> *"The cache secret is here because `AddInfrastructure()` fail-fasts on a missing `ConnectionStrings__cache` in BOTH hosts — but the Worker holds no Redis grant and never opens a cache connection, so the value is present and never used."*

The job's block asserted the opposite three lines away. Both are now consistent, and the module's `secret_env_vars` description records why the value is mandatory for a process that never uses it.

## Change

Adds `connectionstrings-cache` to the job's `key_vault_secrets` and `ConnectionStrings__cache` to its `secret_env_vars` — identical to the Worker.

**No Redis grant is added.** The job still opens no cache connection, so `role-assignments`' existing Api-only asymmetry is unchanged.

## Also found: the workflow's diagnostic step is weaker than intended

`az containerapp job logs show` requires the `containerapp` CLI extension, which isn't present by default. `_reusable-db-migrate.yml` guards that call with `|| true` and prints a Log Analytics fallback message, so a failed migration still fails the deploy correctly — but on a bare runner you'd get the fallback message rather than the logs. Worth hardening in a follow-up; not fixed here to keep this PR to one concept.

The actual diagnosis above came from Log Analytics:

```
ContainerAppConsoleLogs_CL
| where ContainerGroupName_s startswith 'caj-ct-uat-migrate'
| project TimeGenerated, Log_s | order by TimeGenerated asc
```

## Verification

`terraform fmt -recursive` + `validate` clean. No application code changed.

Still unproven: `SchemaMigrator.RunAsync` has not yet reached its own logic — the previous run died in `AddInfrastructure()` before it. Applying this and re-running the job is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
